### PR TITLE
feat: automatically copy transcriptions to clipboard

### DIFF
--- a/whisprbar/main.py
+++ b/whisprbar/main.py
@@ -510,6 +510,14 @@ def on_recording_stop() -> None:
                 word_count = len(text.split())
                 write_history(text, output_seconds, word_count)
 
+                # Always copy to clipboard
+                try:
+                    import pyperclip
+                    pyperclip.copy(text)
+                    debug(f"Copied to clipboard: {text[:50]}...")
+                except Exception as exc:
+                    debug(f"Failed to copy to clipboard: {exc}")
+
                 # Auto-paste if enabled
                 if cfg.get("auto_paste_enabled"):
                     from whisprbar.paste import perform_auto_paste as auto_paste


### PR DESCRIPTION
Add automatic clipboard copy after every successful transcription, regardless of auto-paste settings. This ensures the text is always available in the clipboard for manual pasting.

Changes:
- After transcription and history write, copy text to clipboard
- Uses pyperclip.copy() with error handling
- Works alongside auto-paste (if enabled)
- Also works when auto-paste is disabled

Benefits:
- Text always available in clipboard (Ctrl+V)
- Works on both X11 and Wayland
- Combines well with Recent menu (click entry → copy to clipboard)
- User has full control: auto-paste OR manual paste

Workflow:
1. Transcription completes
2. Text saved to history
3. Text copied to clipboard ✅
4. Auto-paste (if enabled)

This makes WhisprBar more flexible for different workflows and environments, especially useful on Wayland where auto-paste is limited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)