### PR TITLE
fix: resolve venv isolation issue causing OpenAI client and AppIndica…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -194,8 +194,8 @@ ensure_virtualenv() {
   if [[ -d "$VENV_DIR" ]]; then
     log "Reusing existing virtualenv at $VENV_DIR"
   else
-    log "Creating virtualenv at $VENV_DIR"
-    python3 -m venv "$VENV_DIR"
+    log "Creating virtualenv at $VENV_DIR (with system-site-packages)"
+    python3 -m venv --system-site-packages "$VENV_DIR"
   fi
   log "Upgrading pip"
   "$VENV_DIR/bin/python" -m pip install --upgrade pip

--- a/whisprbar-launcher.sh
+++ b/whisprbar-launcher.sh
@@ -32,7 +32,8 @@ if [[ -f "$ENV_FILE" ]]; then
   set +a
 fi
 
-export PYTHONPATH="/usr/lib/python3/dist-packages:/usr/lib/python3.12/dist-packages:${PYTHONPATH:-}"
+# PYTHONPATH removed - venv should be isolated
+# export PYTHONPATH="/usr/lib/python3/dist-packages:/usr/lib/python3.12/dist-packages:${PYTHONPATH:-}"
 
 APP_DIR="${WHISPRBAR_HOME:-$SCRIPT_DIR}"
 VENV_DIR="$APP_DIR/.venv"


### PR DESCRIPTION
…tor failures

## Problem
The PYTHONPATH export in whisprbar-launcher.sh forced the venv to use system packages, causing two critical issues:

1. **OpenAI client failure**: Old system typing_extensions (missing Sentinel) was loaded instead of venv version, breaking OpenAI API initialization

2. **Missing tray icon**: Without system-site-packages, venv couldn't access gi/AppIndicator3, causing fallback to PyStray Xorg which doesn't work well with Cinnamon desktop

## Root Cause
Line 35 in whisprbar-launcher.sh:
```bash
export PYTHONPATH="/usr/lib/python3/dist-packages:..."
```

This breaks venv isolation by forcing system packages to take precedence, leading to version conflicts.

## Solution
1. **Removed PYTHONPATH export** from whisprbar-launcher.sh
   - Venv now properly isolated
   - Can still access system packages via --system-site-packages flag

2. **Updated install.sh** to create venv with --system-site-packages
   - Allows access to system gi/AppIndicator3 (not pip-installable)
   - Venv packages (like typing_extensions) still override system versions
   - Best of both worlds: system integration + correct dependencies

## Testing
- ✅ OpenAI client initializes correctly
- ✅ AppIndicator backend selected (instead of PyStray Xorg)
- ✅ Tray icon visible in Cinnamon desktop
- ✅ Transcription working end-to-end
- ✅ Auto-paste functioning correctly

## Impact
- Fresh installations: Will work correctly out of the box
- Existing installations: Need to recreate venv with: ```bash cd ~/WhisprBar rm -rf .venv ./install.sh ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)