### PR TITLE
Fix audio queue blocking in recording callback

### DIFF
--- a/whisprbar/audio.py
+++ b/whisprbar/audio.py
@@ -123,10 +123,16 @@ def recording_callback(indata, frames, time_info, status):
     # Copy data once to avoid multiple copies
     data_copy = indata.copy()
 
+    # Use non-blocking put to prevent callback thread blocking
     with audio_queue_lock:
         queue_obj = AUDIO_QUEUE
         if queue_obj is not None:
-            queue_obj.put(data_copy)
+            try:
+                queue_obj.put_nowait(data_copy)
+            except queue.Full:
+                # Queue overflow during recording - should only happen with very long
+                # recordings or if stop_recording() is delayed. Log warning but continue.
+                print("[WARN] Audio queue full, dropping frame", file=sys.stderr)
 
     # Also feed to VAD monitor queue if it exists
     with vad_monitor_lock:
@@ -239,7 +245,11 @@ def start_recording() -> None:
     update_device_index()
 
     try:
-        queue_obj: queue.Queue = queue.Queue()
+        # Bounded queue to prevent unbounded memory growth during long recordings
+        # maxsize=500 provides ~32 seconds of buffering (500 blocks * 1024 samples / 16000 Hz)
+        # This is far more than the max 2-second grace period, providing safety margin
+        # while preventing memory issues. Uses put_nowait() to avoid callback blocking.
+        queue_obj: queue.Queue = queue.Queue(maxsize=500)
         with audio_queue_lock:
             AUDIO_QUEUE = queue_obj
 


### PR DESCRIPTION
Problem:
- Unbounded queue can cause memory growth during very long recordings
- Bounded queue with blocking put() would hang audio callback thread
- Bot correctly identified blocking risk in code review

Solution:
- Use bounded queue (maxsize=500, ~32 seconds) to prevent memory growth
- Use put_nowait() instead of put() to prevent callback blocking
- Add proper exception handling for queue.Full with warnings
- Maintains same pattern as VAD monitor queue

Technical Details:
- maxsize=500 provides 32 seconds of buffering (500 * 1024 / 16000)
- Far exceeds max 2-second grace period, provides safety margin
- Queue overflow only possible with severe system delays
- Dropped frames logged as warnings for debugging

Addresses bot review comment about callback blocking issue.