### PR TITLE
Restrict temp file cleanup to WhisprBar only

### DIFF
--- a/whisprbar/main.py
+++ b/whisprbar/main.py
@@ -683,6 +683,11 @@ def main() -> None:
     load_config()
     debug("Config loaded")
 
+    # Clean up old temp files from previous crashes
+    from whisprbar.utils import cleanup_old_temp_files
+    cleanup_old_temp_files()
+    debug("Old temp files cleaned up")
+
     # Detect session type
     debug("Detecting session type...")
     state["session_type"] = detect_session_type()

--- a/whisprbar/transcription.py
+++ b/whisprbar/transcription.py
@@ -133,8 +133,10 @@ class OpenAITranscriber(Transcriber):
             pcm = np.clip(audio, -1.0, 1.0)
             pcm16 = (pcm * 32767).astype(np.int16)
 
-            # Write to temp WAV file
-            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            # Write to temp WAV file in WhisprBar's temp directory
+            from .utils import get_whisprbar_temp_dir
+            temp_dir = get_whisprbar_temp_dir()
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False, dir=temp_dir) as tmp:
                 tmp_path = Path(tmp.name)
 
             try:

--- a/whisprbar/utils.py
+++ b/whisprbar/utils.py
@@ -776,3 +776,55 @@ def play_audio_feedback(sound_type: str = "start") -> None:
             debug(f"aplay failed: {exc}")
 
     debug("No audio playback command available (paplay/aplay)")
+
+
+def get_whisprbar_temp_dir() -> Path:
+    """Get WhisprBar-specific temporary directory.
+
+    Creates and returns a directory unique to WhisprBar for temporary files.
+    This prevents conflicts with other applications' temp files.
+
+    Returns:
+        Path to WhisprBar temp directory (e.g., /tmp/whisprbar-1000/)
+    """
+    # Use user ID to avoid conflicts in multi-user systems
+    uid = os.getuid()
+    temp_dir = Path("/tmp") / f"whisprbar-{uid}"
+    temp_dir.mkdir(mode=0o700, exist_ok=True)
+    return temp_dir
+
+
+def cleanup_old_temp_files() -> None:
+    """Clean up old WhisprBar temporary files left behind by crashes.
+
+    WhisprBar creates temporary WAV files for transcription. If the process
+    crashes, these files are not cleaned up automatically. This function
+    removes temp files older than 1 hour from WhisprBar's temp directory.
+
+    Only targets files in WhisprBar's dedicated temp directory, never touches
+    other applications' files.
+    """
+    import time
+
+    try:
+        temp_dir = get_whisprbar_temp_dir()
+        current_time = time.time()
+        one_hour_ago = current_time - 3600
+
+        # Find all .wav files in WhisprBar's temp directory
+        cleaned_count = 0
+        for temp_file in temp_dir.glob("*.wav"):
+            try:
+                # Check if file is older than 1 hour
+                if temp_file.stat().st_mtime < one_hour_ago:
+                    temp_file.unlink()
+                    cleaned_count += 1
+                    debug(f"Cleaned up old temp file: {temp_file.name}")
+            except Exception as exc:
+                debug(f"Failed to clean up {temp_file}: {exc}")
+
+        if cleaned_count > 0:
+            debug(f"Cleaned up {cleaned_count} old temp file(s)")
+
+    except Exception as exc:
+        debug(f"Temp file cleanup failed: {exc}")


### PR DESCRIPTION
Changes:
- Add get_whisprbar_temp_dir() function to create /tmp/whisprbar-<uid>/ directory
- Update OpenAI transcriber to use WhisprBar temp directory instead of generic /tmp
- Add cleanup_old_temp_files() that only removes files from WhisprBar's directory
- Call cleanup on application startup to remove stale files from crashes
- Prevents accidental deletion of other applications' temporary WAV files

Security impact:
- Before: Cleanup would remove ANY /tmp/tmp*.wav older than 1 hour
- After: Cleanup only touches files in /tmp/whisprbar-<uid>/ directory
- User-specific directory (mode 0o700) prevents multi-user conflicts

Tested:
- Temp directory creation and permissions
- Cleanup only removes old WhisprBar files
- Generic /tmp files from other apps are never touched