### PR TITLE
Refactor hotkey system and improve thread safety

### DIFF
--- a/whisprbar-launcher.sh
+++ b/whisprbar-launcher.sh
@@ -47,8 +47,8 @@ if [[ ! -x "$PYTHON" ]]; then
   fail "Virtualenv missing. Run 'python3 -m venv .venv' and install dependencies."
 fi
 
-if [[ -z "${OPENAI_API_KEY:-}" ]]; then
-  fail "OPENAI_API_KEY not set. Edit $ENV_FILE and add 'OPENAI_API_KEY=…'"
+if [[ -z "${OPENAI_API_KEY:-}" ]] && [[ -z "${DEEPGRAM_API_KEY:-}" ]] && [[ -z "${ELEVENLABS_API_KEY:-}" ]]; then
+  log "No API key set (OPENAI_API_KEY, DEEPGRAM_API_KEY, or ELEVENLABS_API_KEY). Online transcription will not work until configured in Settings or $ENV_FILE. Local backends (faster-whisper, sherpa-onnx) work without API keys."
 fi
 
 log "Starting WhisprBar..."

--- a/whisprbar/audio.py
+++ b/whisprbar/audio.py
@@ -43,6 +43,7 @@ AUDIO_QUEUE: Optional[queue.Queue] = None
 VAD_MONITOR_QUEUE: Optional[queue.Queue] = None  # Separate queue for VAD monitoring
 audio_queue_lock = threading.Lock()
 vad_monitor_lock = threading.Lock()
+_recording_state_lock = threading.Lock()  # Protects recording_state from concurrent access
 recording_state = {
     "recording": False,
     "stream": None,
@@ -103,7 +104,8 @@ def find_device_index_by_name(name: Optional[str]) -> Optional[int]:
 def update_device_index() -> None:
     """Update device index from current config."""
     idx = find_device_index_by_name(cfg.get("device_name"))
-    recording_state["device_idx"] = idx
+    with _recording_state_lock:
+        recording_state["device_idx"] = idx
 
 
 def recording_callback(indata, frames, time_info, status):
@@ -169,7 +171,10 @@ def vad_auto_stop_monitor() -> None:
     debug(f"VAD auto-stop monitor started (threshold: {silence_threshold}s, max_chunks: {max_chunks})")
 
     try:
-        while recording_state.get("recording"):
+        while True:
+            with _recording_state_lock:
+                if not recording_state.get("recording"):
+                    break
             time.sleep(check_interval)
 
             # Get monitor queue reference
@@ -262,18 +267,22 @@ def start_recording() -> None:
             with vad_monitor_lock:
                 VAD_MONITOR_QUEUE = vad_queue_obj
 
+        with _recording_state_lock:
+            device_idx = recording_state.get("device_idx")
+
         stream = sd.InputStream(
             samplerate=SAMPLE_RATE,
             channels=CHANNELS,
             blocksize=BLOCK_SIZE,
             callback=recording_callback,
             dtype="float32",
-            device=recording_state.get("device_idx"),
+            device=device_idx,
         )
         stream.start()
-        recording_state["stream"] = stream
-        recording_state["recording"] = True
-        recording_state["audio_data"] = None
+        with _recording_state_lock:
+            recording_state["stream"] = stream
+            recording_state["recording"] = True
+            recording_state["audio_data"] = None
 
         debug("Recording started")
 
@@ -308,14 +317,14 @@ def stop_recording() -> Optional[np.ndarray]:
     """
     global AUDIO_QUEUE, VAD_MONITOR_QUEUE
 
-    if not recording_state.get("recording"):
-        return None
+    with _recording_state_lock:
+        if not recording_state.get("recording"):
+            return None
+        recording_state["recording"] = False
+        stream = recording_state.get("stream")
 
     with audio_queue_lock:
         queue_obj = AUDIO_QUEUE
-
-    stream = recording_state.get("stream")
-    recording_state["recording"] = False
 
     frames: List[np.ndarray] = []
 
@@ -334,7 +343,8 @@ def stop_recording() -> Optional[np.ndarray]:
         with contextlib.suppress(Exception):
             stream.stop()
             stream.close()
-    recording_state["stream"] = None
+    with _recording_state_lock:
+        recording_state["stream"] = None
 
     # Drain all remaining frames from queue with early-exit optimization
     # After the stream is stopped, buffered frames arrive briefly then stop.
@@ -379,7 +389,8 @@ def stop_recording() -> Optional[np.ndarray]:
         debug(f"Captured audio duration: {duration:.2f}s, samples: {audio_data.shape[0]}")
 
     # Store audio data in recording state for main.py to access
-    recording_state["audio_data"] = audio_data
+    with _recording_state_lock:
+        recording_state["audio_data"] = audio_data
 
     # Call on_stop callback if set
     if _recording_callbacks.get("on_stop"):
@@ -723,9 +734,10 @@ def set_recording_callbacks(on_start=None, on_stop=None):
 
 
 def get_recording_state() -> dict:
-    """Get current recording state.
-    
+    """Get current recording state (thread-safe snapshot).
+
     Returns:
         Dictionary with recording state information
     """
-    return recording_state.copy()
+    with _recording_state_lock:
+        return recording_state.copy()

--- a/whisprbar/config.py
+++ b/whisprbar/config.py
@@ -31,6 +31,7 @@ DEFAULT_CFG = {
     "notifications_enabled": False,
     "auto_paste_enabled": True,
     "auto_paste_add_newline": True,  # Add newline after each transcription
+    "auto_paste_add_space": True,  # Add trailing space after pasted text
     "paste_sequence": "auto",
     "paste_delay_ms": 250,
     "use_vad": True,  # Enabled by default for better quality
@@ -40,6 +41,10 @@ DEFAULT_CFG = {
     "vad_auto_stop_enabled": False,  # Auto-stop recording after silence
     "vad_auto_stop_silence_seconds": 2.0,  # Silence duration to trigger auto-stop
     "vad_calibration_enabled": False,  # Measure ambient noise before recording
+    "vad_energy_floor": 0.0005,  # Minimum energy threshold for VAD frame detection
+    "vad_padding_ms": 200,  # Padding added around detected speech segments (ms)
+    "vad_min_output_ratio": 0.4,  # Minimum output/input ratio to accept VAD result
+    "vad_mode": 1,  # WebRTC VAD aggressiveness mode (0-3, higher = more aggressive)
     "chunking_enabled": True,  # Split long audio into chunks for faster processing
     "chunk_duration_seconds": 30.0,  # Duration of each chunk
     "chunk_overlap_seconds": 2.0,  # Overlap between chunks for smooth merging

--- a/whisprbar/hotkeys.py
+++ b/whisprbar/hotkeys.py
@@ -249,8 +249,7 @@ def modifier_name(key) -> Optional[str]:
     return MODIFIER_LOOKUP.get(key)
 
 
-# Global hotkey listener instance (legacy single listener)
-_hotkey_listener: Optional[keyboard.Listener] = None
+# Current hotkey binding (used by capture_hotkey and update_hotkey_binding)
 _current_hotkey: HotkeyBinding = (frozenset(), "F9")
 
 # =============================================================================
@@ -527,99 +526,6 @@ def get_hotkey_manager() -> HotkeyManager:
     return _hotkey_manager
 
 
-def start_hotkey_listener(
-    hotkey: HotkeyBinding,
-    on_hotkey: Callable[[], None],
-    on_esc_while_recording: Optional[Callable[[], None]] = None,
-    is_recording: Optional[Callable[[], bool]] = None,
-    is_hotkey_capture_active: Optional[Callable[[], bool]] = None,
-) -> None:
-    """Start global hotkey listener.
-
-    Args:
-        hotkey: Hotkey binding to listen for
-        on_hotkey: Callback when hotkey is pressed
-        on_esc_while_recording: Callback when ESC pressed during recording (optional)
-        is_recording: Function returning True if currently recording (optional)
-        is_hotkey_capture_active: Function returning True if capturing new hotkey (optional)
-    """
-    global _hotkey_listener, _current_hotkey
-
-    # Stop existing listener
-    if _hotkey_listener:
-        _hotkey_listener.stop()
-        _hotkey_listener = None
-
-    _current_hotkey = hotkey
-    active_modifiers: Set[str] = set()
-    active_tokens: Set[str] = set()
-
-    def on_press(key):
-        # Handle ESC during recording
-        if is_recording and is_recording() and key == keyboard.Key.esc:
-            if on_esc_while_recording:
-                on_esc_while_recording()
-            return
-
-        # Ignore keys during hotkey capture
-        if is_hotkey_capture_active and is_hotkey_capture_active():
-            return
-
-        # Check if it's a modifier
-        mod = modifier_name(key)
-        if mod:
-            active_modifiers.add(mod)
-            return
-
-        # Check if it's a recognized key token
-        token = event_to_token(key)
-        if not token:
-            return
-
-        # Check if this matches our hotkey
-        required_mods, required_token = _current_hotkey
-        if token != required_token:
-            return
-
-        # Prevent key repeat
-        if token in active_tokens:
-            return
-
-        active_tokens.add(token)
-
-        # Check if all required modifiers are pressed
-        if required_mods.issubset(active_modifiers):
-            on_hotkey()
-
-    def on_release(key):
-        # Ignore keys during hotkey capture
-        if is_hotkey_capture_active and is_hotkey_capture_active():
-            return
-
-        # Release modifier
-        mod = modifier_name(key)
-        if mod:
-            active_modifiers.discard(mod)
-
-        # Release token
-        token = event_to_token(key)
-        if token:
-            active_tokens.discard(token)
-
-    listener = keyboard.Listener(on_press=on_press, on_release=on_release)
-    listener.daemon = True
-    listener.start()
-    _hotkey_listener = listener
-
-
-def stop_hotkey_listener() -> None:
-    """Stop the global hotkey listener."""
-    global _hotkey_listener
-
-    if _hotkey_listener:
-        _hotkey_listener.stop()
-        _hotkey_listener = None
-
 
 def get_current_hotkey() -> HotkeyBinding:
     """Get the currently configured hotkey.
@@ -768,7 +674,11 @@ def update_hotkey_binding(
 
     # Save to config
     cfg["hotkey"] = hotkey_to_config(_current_hotkey)
-    save_config(cfg)
+    # Also update the hotkeys dict for the new multi-hotkey format
+    if "hotkeys" not in cfg:
+        cfg["hotkeys"] = {}
+    cfg["hotkeys"]["toggle_recording"] = hotkey_to_config(_current_hotkey)
+    save_config()
 
     # Notify user
     if notify_change:

--- a/whisprbar/main.py
+++ b/whisprbar/main.py
@@ -34,12 +34,10 @@ from whisprbar.audio import (
 )
 from whisprbar.transcription import transcribe_audio, get_transcriber
 from whisprbar.hotkeys import (
-    start_hotkey_listener,
-    stop_hotkey_listener,
     parse_hotkey,
     get_hotkey_manager,
 )
-from whisprbar.paste import is_wayland_session, PASTE_OPTIONS
+from whisprbar.paste import is_wayland_session
 from whisprbar.ui import (
     maybe_show_first_run_diagnostics,
     open_diagnostics_window,
@@ -142,9 +140,9 @@ class AppState:
             self._recording = False
             self._transcribing = False
 
-    # Proxy methods for non-threaded state (for backwards compatibility)
+    # Proxy methods for state access (all thread-safe via self._lock)
     def get(self, key: str, default: Any = None) -> Any:
-        """Get state value (thread-safe for recording/transcribing/last_transcript/shutdown_requested)."""
+        """Get state value (thread-safe)."""
         if key == "recording":
             return self.recording
         elif key == "transcribing":
@@ -154,10 +152,11 @@ class AppState:
         elif key == "shutdown_requested":
             return self.shutdown_requested
         else:
-            return self._state.get(key, default)
+            with self._lock:
+                return self._state.get(key, default)
 
     def __getitem__(self, key: str) -> Any:
-        """Dict-style access."""
+        """Dict-style access (thread-safe)."""
         if key == "recording":
             return self.recording
         elif key == "transcribing":
@@ -167,10 +166,11 @@ class AppState:
         elif key == "shutdown_requested":
             return self.shutdown_requested
         else:
-            return self._state[key]
+            with self._lock:
+                return self._state[key]
 
     def __setitem__(self, key: str, value: Any):
-        """Dict-style assignment."""
+        """Dict-style assignment (thread-safe)."""
         if key == "recording":
             self.recording = value
         elif key == "transcribing":
@@ -180,7 +180,8 @@ class AppState:
         elif key == "shutdown_requested":
             self.shutdown_requested = value
         else:
-            self._state[key] = value
+            with self._lock:
+                self._state[key] = value
 
 
 # Global application state (thread-safe)
@@ -244,7 +245,7 @@ def ensure_stdin_open() -> None:
         # Recreate stdin file object
         try:
             sys.stdin.close()
-        except:
+        except Exception:
             pass
         sys.stdin = os.fdopen(0, 'r')
 
@@ -397,30 +398,11 @@ def toggle_recording() -> None:
         start_recording()
 
 
-def set_language(language: str) -> None:
-    """Change transcription language (menu callback)."""
-    if language not in {"de", "en"}:
-        return
-    cfg["language"] = language
-    save_config(cfg)
-    notify(f"Language set to {language}.")
-    refresh_menu(get_callbacks(), state)
-
-
-def set_device(name: str) -> None:
-    """Change audio input device (menu callback)."""
-    cfg["device_name"] = name
-    save_config(cfg)
-    update_device_index()
-    label = name or "System Default"
-    notify(f"Input device set to {label}.")
-    refresh_menu(get_callbacks(), state)
-
 
 def toggle_notifications() -> None:
     """Toggle notifications on/off (menu callback)."""
     cfg["notifications_enabled"] = not cfg.get("notifications_enabled", True)
-    save_config(cfg)
+    save_config()
     notify_state = "on" if cfg["notifications_enabled"] else "off"
     if cfg["notifications_enabled"]:
         notify(f"Notifications {notify_state}.")
@@ -430,7 +412,7 @@ def toggle_notifications() -> None:
 def toggle_auto_paste() -> None:
     """Toggle auto-paste on/off (menu callback)."""
     cfg["auto_paste_enabled"] = not cfg.get("auto_paste_enabled", False)
-    save_config(cfg)
+    save_config()
     state_txt = "enabled" if cfg["auto_paste_enabled"] else "disabled"
     notify(f"Auto-paste {state_txt}.")
 
@@ -444,15 +426,6 @@ def toggle_auto_paste() -> None:
     refresh_menu(get_callbacks(), state)
 
 
-def set_paste_sequence(seq: str) -> None:
-    """Change paste sequence (menu callback)."""
-    if seq not in PASTE_OPTIONS:
-        return
-    cfg["paste_sequence"] = seq
-    save_config(cfg)
-    notify(f"Paste sequence set to {PASTE_OPTIONS[seq]}.")
-    refresh_menu(get_callbacks(), state)
-
 
 def toggle_vad() -> None:
     """Toggle VAD on/off (menu callback)."""
@@ -460,7 +433,7 @@ def toggle_vad() -> None:
         notify("WebRTC VAD not installed.")
         return
     cfg["use_vad"] = not cfg.get("use_vad", False)
-    save_config(cfg)
+    save_config()
     state_txt = "enabled" if cfg["use_vad"] else "disabled"
     notify(f"VAD {state_txt}.")
     refresh_menu(get_callbacks(), state)
@@ -518,11 +491,8 @@ def get_callbacks() -> Dict[str, Any]:
         "toggle_recording": toggle_recording,
         "open_settings": open_settings_callback,
         "open_diagnostics": open_diagnostics_callback,
-        "set_language": set_language,
-        "set_device": set_device,
         "toggle_notifications": toggle_notifications,
         "toggle_auto_paste": toggle_auto_paste,
-        "set_paste_sequence": set_paste_sequence,
         "toggle_vad": toggle_vad,
         "copy_to_clipboard": copy_to_clipboard_callback,
         "clear_history": clear_history_callback,

--- a/whisprbar/transcription.py
+++ b/whisprbar/transcription.py
@@ -881,51 +881,8 @@ def get_transcriber() -> Transcriber:
         return _transcriber
 
 
-def split_audio_into_chunks(
-    audio: np.ndarray,
-) -> List[Tuple[np.ndarray, int, int]]:
-    """Split audio into overlapping chunks for parallel processing.
-
-    Args:
-        audio: Audio data as float32 numpy array
-
-    Returns:
-        List of (chunk_audio, start_sample, end_sample) tuples
-    """
-    duration_seconds = audio.size / SAMPLE_RATE
-    chunk_duration = max(5.0, float(cfg.get("chunk_duration_seconds", 30.0)))
-    overlap_duration = max(
-        0.5, min(chunk_duration * 0.2, float(cfg.get("chunk_overlap_seconds", 2.0)))
-    )
-
-    chunk_samples = int(chunk_duration * SAMPLE_RATE)
-    overlap_samples = int(overlap_duration * SAMPLE_RATE)
-    step_samples = chunk_samples - overlap_samples
-
-    chunks: List[Tuple[np.ndarray, int, int]] = []
-    start = 0
-
-    while start < audio.size:
-        end = min(start + chunk_samples, audio.size)
-        chunk = audio[start:end]
-
-        # Skip chunks that are too short (min 1 second)
-        if chunk.size < int(SAMPLE_RATE * 1.0):
-            break
-
-        chunks.append((chunk, start, end))
-
-        # If we've reached the end, stop
-        if end >= audio.size:
-            break
-
-        start += step_samples
-
-    debug(
-        f"Split {duration_seconds:.1f}s audio into {len(chunks)} chunks "
-        f"(chunk={chunk_duration:.1f}s, overlap={overlap_duration:.1f}s)"
-    )
-    return chunks
+# split_audio_into_chunks is defined in audio.py (single source of truth)
+from .audio import split_audio_into_chunks
 
 
 def transcribe_chunk(

--- a/whisprbar/ui.py
+++ b/whisprbar/ui.py
@@ -761,10 +761,10 @@ def hide_live_overlay() -> None:
         print(f"[WARN] Failed to schedule overlay hide: {exc}", file=sys.stderr)
         # Fallback: destroy immediately
         try:
-            if _overlay_window:
-                _overlay_window.destroy()
+            if window_ref:
+                window_ref.destroy()
                 _overlay_window = None
-        except:
+        except Exception:
             pass
 
 
@@ -970,7 +970,7 @@ def open_settings_window(cfg: dict, state: dict, on_save: Optional[Callable] = N
                     try:
                         binding = parse_hotkey(current_hotkey)
                         display = hotkey_to_label(binding)
-                    except:
+                    except Exception:
                         display = current_hotkey or "Nicht gesetzt"
                 else:
                     display = "Nicht gesetzt"
@@ -988,7 +988,7 @@ def open_settings_window(cfg: dict, state: dict, on_save: Optional[Callable] = N
                 try:
                     hotkey_binding = parse_hotkey(hotkey_str)
                     display_label = hotkey_to_label(hotkey_binding)
-                except:
+                except Exception:
                     display_label = hotkey_str or "Nicht gesetzt"
             else:
                 display_label = "Nicht gesetzt"

--- a/whisprbar/utils.py
+++ b/whisprbar/utils.py
@@ -507,11 +507,9 @@ def collect_diagnostics() -> List[DiagnosticResult]:
     return results
 
 
-def ensure_directories() -> None:
-    """Ensure all required directories exist."""
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
-    HIST_FILE.touch(exist_ok=True)
-    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+# Re-export ensure_directories from config (single source of truth)
+# Imported by tray.py and other modules via utils
+from .config import ensure_directories  # noqa: F811
 
 
 def read_history(limit: int = 10) -> List[Dict[str, any]]:


### PR DESCRIPTION
## Summary
This PR refactors the hotkey handling system to use a manager-based approach instead of legacy global listeners, improves thread safety across audio recording state, consolidates duplicate code, and removes unused menu callbacks.

## Key Changes

### Hotkey System Refactoring
- **Removed legacy hotkey listener functions**: `start_hotkey_listener()` and `stop_hotkey_listener()` have been removed in favor of the `HotkeyManager` class
- **Simplified hotkey state**: Removed `_hotkey_listener` global variable; now only `_current_hotkey` is maintained
- **Updated config handling**: `update_hotkey_binding()` now saves to both legacy `hotkey` and new `hotkeys` dict format for backwards compatibility
- **Removed hotkey listener imports**: Cleaned up `main.py` to remove references to deprecated listener functions

### Thread Safety Improvements
- **Audio recording state protection**: Added `_recording_state_lock` to protect concurrent access to `recording_state` dictionary in `audio.py`
- **Protected critical sections**: Wrapped all reads/writes to `recording_state` with lock acquisition in:
  - `update_device_index()`
  - `vad_auto_stop_monitor()`
  - `start_recording()`
  - `stop_recording()`
  - `get_recording_state()`
- **State proxy improvements**: Enhanced `AppState` class in `main.py` with proper lock usage for all non-atomic state access

### Code Consolidation
- **Single source of truth for audio chunking**: Moved `split_audio_into_chunks()` to `audio.py` and imported it in `transcription.py` to eliminate duplication
- **Centralized directory management**: Re-exported `ensure_directories()` from `config.py` in `utils.py` to maintain single source of truth
- **Removed unused callbacks**: Deleted `set_language()`, `set_device()`, and `set_paste_sequence()` menu callbacks from `main.py` (likely moved to settings UI)

### Configuration Updates
- **New VAD options**: Added `vad_energy_floor`, `vad_padding_ms`, and `vad_min_output_ratio` configuration options
- **Auto-paste enhancement**: Added `auto_paste_add_space` config option for trailing space control
- **Simplified config saves**: Changed `save_config(cfg)` calls to `save_config()` (no argument) throughout

### Launcher Script Improvements
- **Flexible API key validation**: Updated `whisprbar-launcher.sh` to accept multiple API key options (OpenAI, Deepgram, ElevenLabs) instead of requiring only OpenAI
- **Better error messaging**: Changed from hard failure to informational message about local backends being available without API keys

### Code Quality
- **Exception handling**: Replaced bare `except:` with `except Exception:` for better exception specificity
- **Documentation**: Updated docstrings to clarify thread-safety guarantees
- **Bug fix**: Fixed overlay window reference in `ui.py` error handling to use correct variable name

## Implementation Details
- The refactoring maintains backwards compatibility by supporting both old and new hotkey config formats
- Thread safety is achieved through consistent use of locks around shared state access, preventing race conditions in multi-threaded recording scenarios
- The removal of legacy hotkey listeners simplifies the codebase while the `HotkeyManager` provides a more maintainable architecture

https://claude.ai/code/session_012f5vjN5T2iow6sSR8ceYaQ