### PR TITLE
test: stabilize auto-paste tests by mocking clipboard copy

### DIFF
--- a/tests/test_paste.py
+++ b/tests/test_paste.py
@@ -163,12 +163,13 @@ def test_perform_auto_paste_clipboard_only(monkeypatch, mock_config):
     mock_config["paste_sequence"] = "auto"
     paste.cfg = mock_config
 
-    with patch("whisprbar.paste.notify") as mock_notify:
-        paste.perform_auto_paste("Test text")
+    with patch("whisprbar.paste.copy_to_clipboard", return_value=True):
+        with patch("whisprbar.paste.notify") as mock_notify:
+            paste.perform_auto_paste("Test text")
 
-        # Should show notification on Wayland
-        mock_notify.assert_called_once()
-        assert "clipboard" in mock_notify.call_args[0][0].lower()
+            # Should show notification on Wayland
+            mock_notify.assert_called_once()
+            assert "clipboard" in mock_notify.call_args[0][0].lower()
 
 
 @pytest.mark.unit
@@ -200,16 +201,17 @@ def test_perform_auto_paste_ctrl_v_with_xdotool(monkeypatch, mock_config):
     mock_run = MagicMock()
     mock_run.returncode = 0
 
-    with patch("shutil.which", return_value="/usr/bin/xdotool"):
-        with patch("subprocess.run", return_value=mock_run) as mock_subprocess:
-            paste.perform_auto_paste("Test")
+    with patch("whisprbar.paste.copy_to_clipboard", return_value=True):
+        with patch("shutil.which", return_value="/usr/bin/xdotool"):
+            with patch("subprocess.run", return_value=mock_run) as mock_subprocess:
+                paste.perform_auto_paste("Test")
 
-            # Should call xdotool
-            mock_subprocess.assert_called_once()
-            args = mock_subprocess.call_args[0][0]
-            assert "xdotool" in args[0]
-            assert "key" in args
-            assert "ctrl+v" in args
+                # Should call xdotool
+                mock_subprocess.assert_called_once()
+                args = mock_subprocess.call_args[0][0]
+                assert "xdotool" in args[0]
+                assert "key" in args
+                assert "ctrl+v" in args
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Motivation
- Two unit tests for auto-paste were flaky because they depended on the host clipboard tooling being available and therefore failed in some environments.

### Description
- Mock `whisprbar.paste.copy_to_clipboard` in `tests/test_paste.py` for `test_perform_auto_paste_clipboard_only` and `test_perform_auto_paste_ctrl_v_with_xdotool` so the tests focus on notification and xdotool invocation behavior only.
- Kept assertions unchanged and scoped the mocks to the affected test blocks to avoid altering other test behavior.

### Testing
- Ran `pytest -q tests/test_paste.py` and the file's tests passed (13 passed, 4 skipped).
- Ran full test suite with `pytest -q` and it completed successfully (76 passed, 31 skipped, 1 warning).
- Previously `pytest -q` produced 2 failures in `tests/test_paste.py`, which are resolved by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e688eef0832b8d21e4b9a2ba3560)