### PR TITLE
feat: wire up animated recording indicator to recording lifecycle

### DIFF
--- a/whisprbar/audio/recorder.py
+++ b/whisprbar/audio/recorder.py
@@ -31,6 +31,7 @@ recording_state = {
 _recording_callbacks = {
     "on_start": None,
     "on_stop": None,
+    "on_audio_level": None,
 }
 
 # Lazy-loaded sounddevice module (import can block/fail in headless CI)
@@ -157,6 +158,17 @@ def recording_callback(indata, frames, time_info, status):
             except queue.Full:
                 # Should never happen with unbounded queue, but handle defensively
                 print("[ERROR] Audio queue unexpectedly full, dropping frame", file=sys.stderr)
+
+    # Feed audio level to recording indicator
+    if _recording_callbacks.get("on_audio_level"):
+        try:
+            import numpy as np
+            rms = float(np.sqrt(np.mean(data_copy.astype(np.float32) ** 2)))
+            # Normalize: typical speech RMS ~0.01-0.1, scale to 0.0-1.0
+            level = min(1.0, rms * 10.0)
+            _recording_callbacks["on_audio_level"](level)
+        except Exception:
+            pass
 
     # Also feed to VAD monitor queue if it exists
     from .vad import vad_monitor_lock, VAD_MONITOR_QUEUE
@@ -347,15 +359,17 @@ def stop_recording() -> Optional[np.ndarray]:
 # Callback Management
 # =============================================================================
 
-def set_recording_callbacks(on_start=None, on_stop=None):
+def set_recording_callbacks(on_start=None, on_stop=None, on_audio_level=None):
     """Set callbacks for recording events.
 
     Args:
         on_start: Function to call when recording starts
         on_stop: Function to call when recording stops
+        on_audio_level: Function(float) called per audio frame with level 0.0-1.0
     """
     _recording_callbacks["on_start"] = on_start
     _recording_callbacks["on_stop"] = on_stop
+    _recording_callbacks["on_audio_level"] = on_audio_level
 
 
 def get_recording_state() -> dict:

--- a/whisprbar/config.py
+++ b/whisprbar/config.py
@@ -79,6 +79,11 @@ DEFAULT_CFG = {
     "audio_feedback_enabled": True,  # Play sounds on recording start/stop/completion
     "audio_feedback_volume": 0.3,  # Volume for audio feedback (0.0-1.0)
     "min_audio_energy": 0.0008,  # Minimum audio energy to prevent hallucinations (0.0001-0.01)
+    "recording_indicator_enabled": True,  # Show animated recording indicator
+    "recording_indicator_style": "soundwave",  # Style: soundwave, pulse, minimal
+    "recording_indicator_position": "bottom-center",  # Position: bottom-center, top-right, etc.
+    "recording_indicator_size": "normal",  # Size: small, normal, large
+    "recording_indicator_opacity": 0.85,  # Opacity (0.0-1.0)
 }
 
 # Global config instance (loaded from disk + defaults)

--- a/whisprbar/main.py
+++ b/whisprbar/main.py
@@ -655,6 +655,10 @@ def on_recording_start() -> None:
     refresh_menu(get_callbacks(), state)
     debug("Recording started")
 
+    # Show animated recording indicator
+    from whisprbar.ui.recording_indicator import show_recording_indicator, PHASE_RECORDING
+    show_recording_indicator(PHASE_RECORDING, cfg)
+
     # Play audio feedback
     play_audio_feedback("start")
 
@@ -667,6 +671,10 @@ def on_recording_stop() -> None:
     refresh_menu(get_callbacks(), state)
     debug("Recording stopped, starting transcription")
 
+    # Switch indicator to processing phase
+    from whisprbar.ui.recording_indicator import show_recording_indicator, PHASE_PROCESSING
+    show_recording_indicator(PHASE_PROCESSING, cfg)
+
     # Confirm stop immediately, before transcription work begins.
     play_audio_feedback("stop")
 
@@ -676,6 +684,8 @@ def on_recording_stop() -> None:
 
     if audio_data is None:
         debug("No audio data available")
+        from whisprbar.ui.recording_indicator import hide_recording_indicator
+        hide_recording_indicator()
         state.transcribing = False
         refresh_tray_indicator(state)
         return
@@ -761,8 +771,10 @@ def on_recording_stop() -> None:
                 hide_live_overlay()
                 return
 
-            # Update overlay
+            # Update overlay and indicator
             update_live_overlay("Transcribing...", "Processing...")
+            from whisprbar.ui.recording_indicator import show_recording_indicator, PHASE_TRANSCRIBING
+            show_recording_indicator(PHASE_TRANSCRIBING, cfg)
 
             # Transcribe (pass language string, not entire cfg)
             text = transcribe_audio(processed, cfg.get("language", "de"))
@@ -770,6 +782,8 @@ def on_recording_stop() -> None:
             if text:
                 debug(f"Transcription: {text}")
                 update_live_overlay(text, "Complete")
+                from whisprbar.ui.recording_indicator import show_recording_indicator, PHASE_COMPLETE
+                show_recording_indicator(PHASE_COMPLETE, cfg)
 
                 # Write to history
                 word_count = len(text.split())
@@ -801,11 +815,15 @@ def on_recording_stop() -> None:
             else:
                 # Empty or failed transcription - notify but don't paste anything
                 debug("Transcription empty or failed")
+                from whisprbar.ui.recording_indicator import show_recording_indicator, PHASE_ERROR
+                show_recording_indicator(PHASE_ERROR, cfg)
                 notify("Transcription failed or empty.")
                 hide_live_overlay()
 
         except Exception as exc:
             debug(f"Transcription error: {exc}")
+            from whisprbar.ui.recording_indicator import show_recording_indicator, PHASE_ERROR
+            show_recording_indicator(PHASE_ERROR, cfg)
             notify(f"Transcription error: {exc}")
         finally:
             # Always cleanup resources, even on exceptions
@@ -1050,9 +1068,10 @@ def main() -> None:
         # Update audio device index
         update_device_index()
 
-        # Set up recording callbacks
+        # Set up recording callbacks (including audio level for indicator)
         from whisprbar.audio import set_recording_callbacks
-        set_recording_callbacks(on_recording_start, on_recording_stop)
+        from whisprbar.ui.recording_indicator import update_audio_level
+        set_recording_callbacks(on_recording_start, on_recording_stop, on_audio_level=update_audio_level)
 
         # Install signal handlers
         install_signal_handlers()


### PR DESCRIPTION
Connect the existing RecordingIndicator (soundwave/pulse/minimal animations) to the actual recording flow:

- RECORDING phase: pulsating soundwave bars reacting to live audio level
- PROCESSING phase: softly pulsing dots while audio is processed
- TRANSCRIBING phase: bouncing dots typing animation
- COMPLETE phase: green checkmark flash, then fade out
- ERROR phase: red X flash, then fade out

Audio level is fed from the sounddevice callback to the indicator in real-time for reactive soundwave bars.

Config defaults added (recording_indicator_enabled, _style, _position, _size, _opacity).

https://claude.ai/code/session_014ZEoLcsgjpQFBaaLyW1pBk

## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [ ] Import test passed (`python -c "from whisprbar import config, audio, transcription"`)
- [ ] Diagnostics passed (`whisprbar --diagnose`)
- [ ] Basic flow tested (record, transcribe, paste)
- [ ] Tested on X11
- [ ] Tested on Wayland (if applicable)

## Checklist

- [ ] Code follows PEP 8 style guidelines
- [ ] Type hints added to public functions
- [ ] Documentation updated (CHANGELOG.md, README.md if needed)
- [ ] No circular dependencies introduced
- [ ] Commit messages follow conventional format
