### PR TITLE
simplify: recording indicator - only soundwave style, wider 240x30 base

### DIFF
--- a/whisprbar/config.py
+++ b/whisprbar/config.py
@@ -80,9 +80,9 @@ DEFAULT_CFG = {
     "audio_feedback_volume": 0.3,  # Volume for audio feedback (0.0-1.0)
     "min_audio_energy": 0.0008,  # Minimum audio energy to prevent hallucinations (0.0001-0.01)
     "recording_indicator_enabled": True,  # Show animated recording indicator
-    "recording_indicator_style": "soundwave",  # Style: soundwave, pulse, minimal
+    "recording_indicator_style": "soundwave",  # Currently only soundwave
     "recording_indicator_position": "top-center",  # Position: top-center, bottom-center, top-left, etc.
-    "recording_indicator_scale": 1.0,        # 0.1 - 2.0 (1.0 = 160x20 base)
+    "recording_indicator_scale": 1.0,        # 0.1 - 2.0 (1.0 = 240x30 base)
     "recording_indicator_opacity": 0.85,  # Opacity (0.0-1.0)
     "recording_indicator_x": None,           # Custom X position (for draggable)
     "recording_indicator_y": None,           # Custom Y position (for draggable)

--- a/whisprbar/config_types.py
+++ b/whisprbar/config_types.py
@@ -150,9 +150,9 @@ class IndicatorConfig:
     """Recording indicator (animated popup) settings."""
 
     recording_indicator_enabled: bool = True
-    recording_indicator_style: str = "soundwave"  # "soundwave", "pulse", "minimal"
+    recording_indicator_style: str = "soundwave"  # Currently only soundwave
     recording_indicator_position: str = "top-center"  # "top-center", "bottom-center", etc.
-    recording_indicator_scale: float = 1.0  # 0.1 - 2.0 (1.0 = 160x20 base)
+    recording_indicator_scale: float = 1.0  # 0.1 - 2.0 (1.0 = 240x30 base)
     recording_indicator_opacity: float = 0.85
     recording_indicator_x: Optional[int] = None
     recording_indicator_y: Optional[int] = None

--- a/whisprbar/ui/recording_indicator.py
+++ b/whisprbar/ui/recording_indicator.py
@@ -1,11 +1,11 @@
 """Animated recording indicator for WhisprBar.
 
-Displays a small, frameless, transparent popup window with animated
+Displays a wide, frameless, transparent popup bar with animated
 visual feedback during recording and transcription:
-- RECORDING: Pulsating soundwave bars that react to audio level
-- PROCESSING: Softly pulsing dots
-- TRANSCRIBING: Running dot indicator (typing animation)
-- COMPLETE: Brief green checkmark flash, then fade out
+- RECORDING: Soundwave bars that react to audio level
+- PROCESSING: Pulsing dots
+- TRANSCRIBING: Bouncing dots (typing animation)
+- COMPLETE: Brief green checkmark, then fade out
 - ERROR: Brief red X, then fade out
 
 Technical: GTK3 DrawingArea + Cairo for custom rendering,
@@ -35,9 +35,9 @@ PHASE_TRANSCRIBING = "transcribing"
 PHASE_COMPLETE = "complete"
 PHASE_ERROR = "error"
 
-# Base dimensions at 100% scale — wide and flat (8:1 ratio)
-BASE_WIDTH = 160
-BASE_HEIGHT = 20
+# Base dimensions at 100% scale — wide bar (8:1 ratio)
+BASE_WIDTH = 240
+BASE_HEIGHT = 30
 
 # Colors (RGBA)
 COLOR_RECORDING = (0.91, 0.30, 0.24, 1.0)      # Red/orange
@@ -94,7 +94,6 @@ class RecordingIndicator:
         # Config
         cfg = cfg or {}
         self._enabled = cfg.get("recording_indicator_enabled", True)
-        self._style = cfg.get("recording_indicator_style", "soundwave")
         self._position = cfg.get("recording_indicator_position", POSITION_TOP_CENTER)
         self._scale = float(cfg.get("recording_indicator_scale", 1.0))
         self._opacity = cfg.get("recording_indicator_opacity", 0.85)
@@ -344,57 +343,12 @@ class RecordingIndicator:
         cr.close_path()
 
     def _draw_recording(self, cr, w, h, alpha) -> None:
-        """Draw recording animation based on selected style."""
+        """Draw soundwave bars that react to audio level."""
         r, g, b, _ = COLOR_RECORDING
         t = self._tick_count / FPS  # Time in seconds
         level = self._audio_level
 
-        if self._style == "pulse":
-            # Horizontal glowing bar that breathes with audio level
-            margin_x = w * 0.1
-            bar_h = h * 0.35
-            cy = h / 2
-            pulse = 0.4 + 0.6 * (0.3 + 0.7 * level) * (0.5 + 0.5 * math.sin(t * 3))
-            bar_w = (w - 2 * margin_x) * pulse
-            bx = (w - bar_w) / 2
-            by = cy - bar_h / 2
-            cap_r = bar_h / 2
-            self._draw_rounded_rect(cr, bx, by, bar_w, bar_h, cap_r)
-            cr.set_source_rgba(r, g, b, alpha * (0.5 + 0.4 * pulse))
-            cr.fill()
-            # Brighter core line
-            core_h = bar_h * 0.4
-            core_y = cy - core_h / 2
-            self._draw_rounded_rect(cr, bx + bar_h * 0.2, core_y, max(bar_w - bar_h * 0.4, 1), core_h, core_h / 2)
-            cr.set_source_rgba(r, g, b, alpha * 0.9)
-            cr.fill()
-            return
-
-        if self._style == "minimal":
-            # Small recording LED dot on left + thin animated line
-            cy = h / 2
-            dot_r = h * 0.2
-            dot_x = w * 0.12
-            pulse = 0.7 + 0.3 * math.sin(t * 3)
-            cr.arc(dot_x, cy, dot_r * pulse, 0, 2 * math.pi)
-            cr.set_source_rgba(r, g, b, alpha)
-            cr.fill()
-            # Subtle glow
-            cr.arc(dot_x, cy, dot_r * 1.8 * pulse, 0, 2 * math.pi)
-            cr.set_source_rgba(r, g, b, alpha * 0.15)
-            cr.fill()
-            # Thin animated line extending right
-            line_h = h * 0.12
-            line_x = dot_x + dot_r * 2.5
-            line_w = (w * 0.8 - line_x) * (0.2 + 0.8 * level)
-            line_y = cy - line_h / 2
-            self._draw_rounded_rect(cr, line_x, line_y, max(line_w, w * 0.05), line_h, line_h / 2)
-            cr.set_source_rgba(r, g, b, alpha * 0.5 * (0.4 + 0.6 * level))
-            cr.fill()
-            return
-
-        # Default: soundwave bars — fill ~85% of the box width
-        num_bars = 9
+        num_bars = 12
         usable_w = w * 0.85
         bar_width = usable_w / (num_bars * 1.8)
         gap = bar_width * 0.8

--- a/whisprbar/ui/settings.py
+++ b/whisprbar/ui/settings.py
@@ -781,15 +781,6 @@ def open_settings_window(cfg: dict, state: dict, on_save: Optional[Callable] = N
 
         ri_rows: List[Gtk.Widget] = []
 
-        # Style combo
-        ri_style_combo = Gtk.ComboBoxText()
-        for sid, slabel in [("soundwave", "Soundwave"), ("pulse", "Puls"), ("minimal", "Minimal")]:
-            ri_style_combo.append(sid, slabel)
-        ri_style_combo.set_active_id(cfg.get("recording_indicator_style", "soundwave"))
-        ri_style_row = make_row("  Stil", ri_style_combo)
-        ri_rows.append(ri_style_row)
-        adv_page.pack_start(ri_style_row, False, False, 0)
-
         # Position combo
         ri_pos_combo = Gtk.ComboBoxText()
         for pid, plabel in [
@@ -1015,13 +1006,11 @@ def open_settings_window(cfg: dict, state: dict, on_save: Optional[Callable] = N
             cfg["chunking_enabled"] = chunking_switch.get_active()
             # Recording indicator settings
             old_ri_enabled = cfg.get("recording_indicator_enabled")
-            old_ri_style = cfg.get("recording_indicator_style")
             old_ri_position = cfg.get("recording_indicator_position")
             old_ri_scale = cfg.get("recording_indicator_scale")
             old_ri_opacity = cfg.get("recording_indicator_opacity")
 
             cfg["recording_indicator_enabled"] = ri_switch.get_active()
-            cfg["recording_indicator_style"] = ri_style_combo.get_active_id() or "soundwave"
             cfg["recording_indicator_position"] = ri_pos_combo.get_active_id() or "top-center"
             cfg["recording_indicator_scale"] = round(float(ri_scale.get_value()), 1)
             cfg["recording_indicator_opacity"] = round(float(ri_opacity.get_value()), 2)
@@ -1029,7 +1018,6 @@ def open_settings_window(cfg: dict, state: dict, on_save: Optional[Callable] = N
             # Reset indicator singleton if any indicator settings changed
             ri_changed = (
                 old_ri_enabled != cfg["recording_indicator_enabled"]
-                or old_ri_style != cfg["recording_indicator_style"]
                 or old_ri_position != cfg["recording_indicator_position"]
                 or old_ri_scale != cfg["recording_indicator_scale"]
                 or old_ri_opacity != cfg["recording_indicator_opacity"]


### PR DESCRIPTION
- Remove pulse and minimal styles, keep only soundwave
- Change base dimensions from 160x20 to 240x30 (wide bar, not square)
- Increase bars from 9 to 12 for better visual fill
- Remove style dropdown from settings UI
- Scale slider still controls overall size (10%-200%)

https://claude.ai/code/session_01BEntz2tzzawzaasypi5KNF

## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [ ] Import test passed (`python -c "from whisprbar import config, audio, transcription"`)
- [ ] Diagnostics passed (`whisprbar --diagnose`)
- [ ] Basic flow tested (record, transcribe, paste)
- [ ] Tested on X11
- [ ] Tested on Wayland (if applicable)

## Checklist

- [ ] Code follows PEP 8 style guidelines
- [ ] Type hints added to public functions
- [ ] Documentation updated (CHANGELOG.md, README.md if needed)
- [ ] No circular dependencies introduced
- [ ] Commit messages follow conventional format
