### PR TITLE
fix: recording indicator ignores size/scale settings (GTK3 sizing bug)

### DIFF
--- a/whisprbar/config.py
+++ b/whisprbar/config.py
@@ -251,6 +251,13 @@ def validate_config() -> None:
         except (ValueError, TypeError):
             cfg["min_drain_timeout_ms"] = DEFAULT_CFG["min_drain_timeout_ms"]
 
+    # Migrate old recording_indicator_size preset to recording_indicator_scale
+    if "recording_indicator_size" in cfg:
+        size_to_scale = {"small": 0.7, "normal": 1.0, "large": 1.4}
+        old_size = cfg.pop("recording_indicator_size")
+        if "recording_indicator_scale" not in cfg or cfg["recording_indicator_scale"] == DEFAULT_CFG.get("recording_indicator_scale"):
+            cfg["recording_indicator_scale"] = size_to_scale.get(old_size, 1.0)
+
     # Clamp audio feedback volume
     if "audio_feedback_volume" in cfg:
         try:

--- a/whisprbar/ui/recording_indicator.py
+++ b/whisprbar/ui/recording_indicator.py
@@ -176,6 +176,7 @@ class RecordingIndicator:
         window.set_keep_above(True)
         window.set_accept_focus(False)
         window.set_default_size(self._width, self._height)
+        window.resize(self._width, self._height)
         window.set_resizable(False)
 
         # Enable transparency
@@ -187,6 +188,7 @@ class RecordingIndicator:
 
         # Drawing area
         drawing_area = Gtk.DrawingArea()
+        drawing_area.set_size_request(self._width, self._height)
         drawing_area.connect("draw", self._on_draw)
         window.add(drawing_area)
 

--- a/whisprbar/ui/settings.py
+++ b/whisprbar/ui/settings.py
@@ -1026,8 +1026,8 @@ def open_settings_window(cfg: dict, state: dict, on_save: Optional[Callable] = N
                 try:
                     from whisprbar.ui.recording_indicator import reset_recording_indicator
                     reset_recording_indicator()
-                except Exception:
-                    pass
+                except Exception as exc:
+                    print(f"[WARN] Failed to reset recording indicator: {exc}", file=sys.stderr)
 
             cfg["live_overlay_enabled"] = overlay_switch.get_active()
             cfg["live_overlay_font_size"] = int(font_scale.get_value())


### PR DESCRIPTION
The DrawingArea had no set_size_request(), so GTK allocated an arbitrary (often minimal/square) size regardless of window.set_default_size(). Added set_size_request() on DrawingArea and window.resize() for POPUP windows. Also added config migration from old recording_indicator_size presets to new recording_indicator_scale, and error logging for silent settings reset failures.

https://claude.ai/code/session_01BEntz2tzzawzaasypi5KNF

## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [ ] Import test passed (`python -c "from whisprbar import config, audio, transcription"`)
- [ ] Diagnostics passed (`whisprbar --diagnose`)
- [ ] Basic flow tested (record, transcribe, paste)
- [ ] Tested on X11
- [ ] Tested on Wayland (if applicable)

## Checklist

- [ ] Code follows PEP 8 style guidelines
- [ ] Type hints added to public functions
- [ ] Documentation updated (CHANGELOG.md, README.md if needed)
- [ ] No circular dependencies introduced
- [ ] Commit messages follow conventional format
