### PR TITLE
Stream audio to realtime transcribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added streaming transcription sessions for Deepgram and ElevenLabs so supported backends can receive audio while recording is still active.
+- Added runtime latency metadata for audio processing, transcription, Flow processing, paste, and recording-to-first-audio timing.
 - Store successful dictations in a local SQLite transcript database with structured metadata.
 - Added a read-only Analysis tab in settings showing transcript database collection counts and sources.
 
 ### Changed
+- Reduced avoidable local waits by defaulting paste delay to 0 ms and stop-tail grace to 200 ms.
+- Prefer live transcription results before falling back to batch transcription, and skip expensive noise reduction when live ASR already consumed the raw audio.
+- Removed process priority lowering during transcription to keep Linux desktop responsiveness predictable.
 - Aligned transcript database retention with Flow history privacy settings, including auto-delete.
 - Moved the new-PC setup note into `docs/`, added a docs index, and documented the repository layout in the README for a cleaner GitHub landing page.
 - Kept local/offline transcription backends out of the default `requirements.txt` install and documented `faster-whisper` and `sherpa-onnx` as optional packaging extras.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kept local/offline transcription backends out of the default `requirements.txt` install and documented `faster-whisper` and `sherpa-onnx` as optional packaging extras.
 
 ### Fixed
+- Prevented live ASR session ownership races across rapid recordings, cancelled leaked realtime sessions after startup/finish failures, and preserved Deepgram final results that arrive after `CloseStream`.
+- Aligned package metadata and README support badges with the Python 3.10+ syntax used by the current codebase.
 - Aligned `pyproject.toml` with the runtime package version and added regression coverage so packaging metadata cannot drift silently.
 - Removed stale installation documentation references to missing development-log files.
 - Hardened configuration loading and saving: nested defaults no longer leak runtime mutations, reloads reset stale values, config writes create missing parents atomically, and env-file writes reject multiline secret injection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Reduced avoidable local waits by defaulting paste delay to 0 ms and stop-tail grace to 200 ms.
-- Prefer live transcription results before falling back to batch transcription, and skip expensive noise reduction when live ASR already consumed the raw audio.
+- Prefer live transcription results before falling back to batch transcription, start live finalization while local audio cleanup runs, and skip expensive noise reduction when live ASR already consumed the raw audio.
+- Force batch fallback instead of returning partial live text when realtime audio chunks are dropped under load.
 - Removed process priority lowering during transcription to keep Linux desktop responsiveness predictable.
 - Aligned transcript database retention with Flow history privacy settings, including auto-delete.
 - Moved the new-PC setup note into `docs/`, added a docs index, and documented the repository layout in the README for a cleaner GitHub landing page.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/badge/version-1.3.1-blue.svg)](https://github.com/henrik092/whisprBar/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Python](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Platform](https://img.shields.io/badge/platform-Linux-lightgrey.svg)](https://www.linux.org/)
 
 A Linux system tray app for voice-to-text transcription. Press a hotkey, speak, release -- your text is automatically pasted into the active window.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.3.1"
 description = "Linux system tray application for voice-to-text transcription"
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     { name = "Henrik W", email = "henrik092@users.noreply.github.com" },
 ]
@@ -20,8 +20,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
-requires = ["setuptools>=68.0", "wheel"]
-build-backend = "setuptools.backends._legacy:_Backend"
+requires = ["setuptools>=68.0,<77", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "whisprbar"
 version = "1.3.1"
 description = "Linux system tray application for voice-to-text transcription"
 readme = "README.md"
-license = "MIT"
+license = { text = "MIT" }
 requires-python = ">=3.8"
 authors = [
     { name = "Henrik W", email = "henrik092@users.noreply.github.com" },
@@ -36,9 +36,10 @@ dependencies = [
     "Pillow>=10.0.0",
     "pyperclip>=1.8.2",
     "openai>=1.0.0",
-    "webrtcvad>=2.0.10",
+    "webrtcvad>=2.0.10; platform_system != 'Windows'",
     "pynput>=1.7.6",
     "noisereduce>=3.0.0",
+    "websockets>=12.0",
 ]
 
 [project.optional-dependencies]
@@ -50,6 +51,7 @@ dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.11.0",
+    "tomli>=1.1.0; python_version < '3.11'",
 ]
 
 [project.urls]

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -245,6 +245,37 @@ def test_set_recording_callbacks():
 
 
 @pytest.mark.unit
+def test_recording_callback_forwards_audio_chunks_to_streaming_callback(monkeypatch):
+    """Captured frames should be available to a live transcription session."""
+    from whisprbar.audio import recorder
+
+    chunks = []
+    frame = np.array([[0.1], [0.2], [0.3]], dtype=np.float32)
+
+    monkeypatch.setattr(recorder, "AUDIO_QUEUE", queue.Queue())
+    monkeypatch.setattr(recorder.time, "monotonic", lambda: 123.456)
+    monkeypatch.setattr(
+        recorder,
+        "_recording_callbacks",
+        {
+            "on_start": None,
+            "on_stop": None,
+            "on_audio_level": None,
+            "on_audio_chunk": chunks.append,
+        },
+    )
+    with recorder._recording_state_lock:
+        recorder.recording_state["first_audio_at_monotonic"] = None
+
+    recorder.recording_callback(frame, len(frame), None, None)
+
+    assert len(chunks) == 1
+    np.testing.assert_array_equal(chunks[0], frame)
+    assert chunks[0] is not frame
+    assert recorder.recording_state["first_audio_at_monotonic"] == 123.456
+
+
+@pytest.mark.unit
 def test_indicator_level_mapping_makes_normal_speech_visible():
     """Typical speech RMS should drive the recording indicator clearly."""
     from whisprbar.audio.recorder import _audio_rms_to_indicator_level
@@ -314,6 +345,82 @@ def test_start_recording_ignores_concurrent_start_while_stream_initializes(monke
 
     try:
         assert created_streams == 1
+    finally:
+        recorder.stop_recording()
+
+
+@pytest.mark.unit
+def test_start_recording_prepares_live_session_before_stream_callbacks(monkeypatch):
+    """Live streaming setup must run before sounddevice can emit frames."""
+    from whisprbar.audio import recorder
+
+    order = []
+    monotonic_values = [100.0, 100.005]
+    monotonic_current = [100.005]
+
+    def fake_monotonic():
+        if monotonic_values:
+            monotonic_current[0] = monotonic_values.pop(0)
+        else:
+            monotonic_current[0] += 0.05
+        return monotonic_current[0]
+
+    class FakeStream:
+        def __init__(self, **kwargs):
+            self.callback = kwargs["callback"]
+
+        def start(self):
+            order.append("stream_start")
+            self.callback(np.ones((2, 1), dtype=np.float32), 2, None, None)
+
+        def stop(self):
+            return None
+
+        def close(self):
+            return None
+
+    class FakeSoundDevice:
+        InputStream = FakeStream
+
+    with recorder._recording_state_lock:
+        recorder.recording_state.update(
+            {
+                "recording": False,
+                "stream": None,
+                "device_idx": None,
+                "audio_data": None,
+                "generation": 0,
+                "started_at_monotonic": None,
+                "first_audio_at_monotonic": None,
+                "stopped_at_monotonic": None,
+            }
+        )
+        recorder.recording_state.pop("starting", None)
+
+    monkeypatch.setattr(recorder.time, "monotonic", fake_monotonic)
+    monkeypatch.setitem(recorder.cfg, "flow_mode_enabled", False)
+    monkeypatch.setitem(recorder.cfg, "vad_auto_stop_enabled", False)
+    monkeypatch.setattr(recorder, "_get_sounddevice", lambda: FakeSoundDevice())
+    monkeypatch.setattr(recorder, "update_device_index", lambda: None)
+    monkeypatch.setattr(recorder, "_start_max_recording_monitor", lambda _generation: None)
+    monkeypatch.setattr(
+        recorder,
+        "_recording_callbacks",
+        {
+            "on_before_start": lambda: order.append("before_start"),
+            "on_start": lambda: order.append("on_start"),
+            "on_stop": None,
+            "on_audio_level": None,
+            "on_audio_chunk": lambda _chunk: order.append("audio_chunk"),
+        },
+    )
+
+    try:
+        recorder.start_recording()
+
+        assert order == ["before_start", "stream_start", "audio_chunk", "on_start"]
+        assert recorder.recording_state["started_at_monotonic"] == 100.0
+        assert recorder.recording_state["first_audio_at_monotonic"] == 100.005
     finally:
         recorder.stop_recording()
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -276,6 +276,46 @@ def test_recording_callback_forwards_audio_chunks_to_streaming_callback(monkeypa
 
 
 @pytest.mark.unit
+def test_recording_callback_does_not_take_state_lock_while_queue_lock_is_held(monkeypatch):
+    """Audio callback lock ordering must stay compatible with stop_recording()."""
+    from whisprbar.audio import recorder
+
+    frame = np.array([[0.1], [0.2]], dtype=np.float32)
+    queue_lock_held = {"value": False}
+
+    class TrackingQueueLock:
+        def __enter__(self):
+            queue_lock_held["value"] = True
+
+        def __exit__(self, _exc_type, _exc, _tb):
+            queue_lock_held["value"] = False
+
+    class AssertStateLock:
+        def __enter__(self):
+            assert queue_lock_held["value"] is False
+
+        def __exit__(self, _exc_type, _exc, _tb):
+            return False
+
+    monkeypatch.setattr(recorder, "AUDIO_QUEUE", queue.Queue())
+    monkeypatch.setattr(recorder, "audio_queue_lock", TrackingQueueLock())
+    monkeypatch.setattr(recorder, "_recording_state_lock", AssertStateLock())
+    monkeypatch.setattr(
+        recorder,
+        "_recording_callbacks",
+        {
+            "on_start": None,
+            "on_stop": None,
+            "on_audio_level": None,
+            "on_audio_chunk": None,
+            "on_before_start": None,
+        },
+    )
+
+    recorder.recording_callback(frame, len(frame), None, None)
+
+
+@pytest.mark.unit
 def test_indicator_level_mapping_makes_normal_speech_visible():
     """Typical speech RMS should drive the recording indicator clearly."""
     from whisprbar.audio.recorder import _audio_rms_to_indicator_level

--- a/tests/test_config_types.py
+++ b/tests/test_config_types.py
@@ -28,7 +28,7 @@ class TestAudioConfig:
         assert cfg.vad_energy_ratio == 0.05
         assert cfg.noise_reduction_enabled is True
         assert cfg.min_audio_energy == 0.0008
-        assert cfg.stop_tail_grace_ms == 500
+        assert cfg.stop_tail_grace_ms == 200
 
     def test_frozen(self):
         cfg = AudioConfig()
@@ -75,7 +75,7 @@ class TestPasteConfig:
         cfg = PasteConfig()
         assert cfg.auto_paste_enabled is True
         assert cfg.paste_sequence == "auto"
-        assert cfg.paste_delay_ms == 250
+        assert cfg.paste_delay_ms == 0
 
     def test_frozen(self):
         cfg = PasteConfig()

--- a/tests/test_deepgram.py
+++ b/tests/test_deepgram.py
@@ -247,6 +247,21 @@ def test_deepgram_realtime_session_sends_binary_audio_and_finalizes(monkeypatch)
 
 
 @pytest.mark.unit
+def test_deepgram_realtime_session_discards_partial_text_after_queue_overflow(monkeypatch):
+    """Dropped live audio chunks must force batch fallback instead of returning partial text."""
+    monkeypatch.setattr(DeepgramRealtimeSession, "_run_thread", lambda self: None)
+    session = DeepgramRealtimeSession("test-key", "wss://api.deepgram.com/v1/listen")
+    session._result_parts.append("partial live text")
+
+    while not session._audio_queue.full():
+        session._audio_queue.put_nowait(np.ones(1, dtype=np.float32))
+
+    session.push_audio(np.ones(1, dtype=np.float32))
+
+    assert session.finish() is None
+
+
+@pytest.mark.unit
 def test_deepgram_unload_closes_registered_connections():
     """Unload should close currently tracked live connections."""
     transcriber = DeepgramTranscriber()

--- a/tests/test_deepgram.py
+++ b/tests/test_deepgram.py
@@ -247,6 +247,119 @@ def test_deepgram_realtime_session_sends_binary_audio_and_finalizes(monkeypatch)
 
 
 @pytest.mark.unit
+def test_deepgram_realtime_session_supports_legacy_websockets_headers(monkeypatch):
+    """websockets 12.x expects extra_headers before entering the connection context."""
+    attempts = []
+
+    class FailingAdditionalHeadersConnect:
+        async def __aenter__(self):
+            raise TypeError(
+                "BaseEventLoop.create_connection() got an unexpected keyword argument 'additional_headers'"
+            )
+
+        async def __aexit__(self, _exc_type, _exc, _tb):
+            return False
+
+    class WorkingExtraHeadersConnect:
+        async def __aenter__(self):
+            raise RuntimeError("stop before network flow")
+
+        async def __aexit__(self, _exc_type, _exc, _tb):
+            return False
+
+    def fake_connect(uri, **kwargs):
+        attempts.append((uri, kwargs))
+        if "additional_headers" in kwargs:
+            return FailingAdditionalHeadersConnect()
+        if "extra_headers" in kwargs:
+            return WorkingExtraHeadersConnect()
+        raise AssertionError(f"missing websocket headers: {kwargs}")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "websockets",
+        SimpleNamespace(connect=fake_connect),
+    )
+
+    session = DeepgramRealtimeSession("test-key", "wss://api.deepgram.com/v1/listen")
+
+    assert session.finish() is None
+    assert [sorted(kwargs) for _uri, kwargs in attempts] == [
+        ["additional_headers", "open_timeout", "ping_interval"],
+        ["extra_headers", "open_timeout", "ping_interval"],
+    ]
+    assert attempts[1][1]["extra_headers"]["Authorization"] == "Token test-key"
+    assert attempts[1][1]["open_timeout"] == 10
+    assert attempts[1][1]["ping_interval"] == 20
+
+
+@pytest.mark.unit
+def test_deepgram_realtime_session_reads_results_after_close_stream(monkeypatch):
+    """CloseStream can flush final results even when Finalize emits no final event."""
+    from whisprbar.transcription import deepgram as deepgram_module
+
+    sent_payloads = []
+
+    async def immediate_finalize_timeout(awaitable, timeout):
+        if isinstance(awaitable, asyncio.Task):
+            return await awaitable
+        awaitable.close()
+        raise asyncio.TimeoutError
+
+    class FakeWebSocket:
+        def __init__(self):
+            self._messages = asyncio.Queue()
+
+        async def send(self, payload):
+            sent_payloads.append(payload)
+            if isinstance(payload, str) and json.loads(payload).get("type") == "CloseStream":
+                await self._messages.put(
+                    json.dumps(
+                        {
+                            "type": "Results",
+                            "is_final": True,
+                            "channel": {
+                                "alternatives": [{"transcript": "close stream final"}]
+                            },
+                        }
+                    )
+                )
+                await self._messages.put(None)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            message = await self._messages.get()
+            if message is None:
+                raise StopAsyncIteration
+            return message
+
+    class FakeConnect:
+        async def __aenter__(self):
+            return FakeWebSocket()
+
+        async def __aexit__(self, _exc_type, _exc, _tb):
+            return False
+
+    monkeypatch.setattr(deepgram_module.asyncio, "wait_for", immediate_finalize_timeout)
+    monkeypatch.setitem(
+        sys.modules,
+        "websockets",
+        SimpleNamespace(connect=lambda _uri, **_kwargs: FakeConnect()),
+    )
+
+    session = DeepgramRealtimeSession("test-key", "wss://api.deepgram.com/v1/listen")
+
+    assert session.finish() == "close stream final"
+    assert [
+        json.loads(payload)["type"]
+        for payload in sent_payloads
+        if isinstance(payload, str)
+    ] == ["Finalize", "CloseStream"]
+
+
+@pytest.mark.unit
 def test_deepgram_realtime_session_discards_partial_text_after_queue_overflow(monkeypatch):
     """Dropped live audio chunks must force batch fallback instead of returning partial text."""
     monkeypatch.setattr(DeepgramRealtimeSession, "_run_thread", lambda self: None)
@@ -259,6 +372,42 @@ def test_deepgram_realtime_session_discards_partial_text_after_queue_overflow(mo
     session.push_audio(np.ones(1, dtype=np.float32))
 
     assert session.finish() is None
+
+
+@pytest.mark.unit
+def test_deepgram_realtime_session_discards_partial_text_when_close_drops_audio(monkeypatch):
+    """A full queue at finish means the sentinel displaced live audio."""
+    monkeypatch.setattr(DeepgramRealtimeSession, "_run_thread", lambda self: None)
+    session = DeepgramRealtimeSession("test-key", "wss://api.deepgram.com/v1/listen")
+    session._result_parts.append("partial live text")
+
+    while not session._audio_queue.full():
+        session._audio_queue.put_nowait(np.ones(1, dtype=np.float32))
+
+    assert session.finish() is None
+
+
+@pytest.mark.unit
+def test_deepgram_realtime_session_cancels_worker_after_finish_timeout(monkeypatch):
+    """Timed-out realtime workers should be cancelled before batch fallback."""
+    monkeypatch.setattr(DeepgramRealtimeSession, "_run_thread", lambda self: None)
+    session = DeepgramRealtimeSession("test-key", "wss://api.deepgram.com/v1/listen")
+    joins = []
+    cancelled = []
+
+    class HungThread:
+        def join(self, timeout=None):
+            joins.append(timeout)
+
+        def is_alive(self):
+            return True
+
+    session._thread = HungThread()
+    monkeypatch.setattr(session, "cancel", lambda: cancelled.append(True))
+
+    assert session.finish() is None
+    assert joins == [15.0]
+    assert cancelled == [True]
 
 
 @pytest.mark.unit

--- a/tests/test_deepgram.py
+++ b/tests/test_deepgram.py
@@ -1,10 +1,16 @@
 """Unit tests for the Deepgram transcription backend."""
 
 import gc
+import asyncio
+import json
 import socket
+import sys
+from types import SimpleNamespace
+
+import numpy as np
 import pytest
 
-from whisprbar.transcription.deepgram import DeepgramTranscriber
+from whisprbar.transcription.deepgram import DeepgramRealtimeSession, DeepgramTranscriber
 
 
 class FakeResponse:
@@ -133,6 +139,111 @@ def test_deepgram_build_request_path_preserves_explicit_locale_tags():
 
     assert "language=en-US" in transcriber._build_request_path("en-US")
     assert "language=de-CH" in transcriber._build_request_path("de-CH")
+
+
+@pytest.mark.unit
+def test_deepgram_build_streaming_url_uses_raw_pcm_parameters():
+    """Deepgram live streams receive raw PCM16 with explicit audio parameters."""
+    transcriber = DeepgramTranscriber()
+
+    url = transcriber._build_streaming_url("de")
+
+    assert url.startswith("wss://api.deepgram.com/v1/listen?")
+    assert "model=nova-3" in url
+    assert "language=multi" in url
+    assert "encoding=linear16" in url
+    assert "sample_rate=16000" in url
+    assert "channels=1" in url
+    assert "interim_results=true" in url
+
+
+@pytest.mark.unit
+def test_deepgram_start_streaming_creates_live_session(monkeypatch):
+    """Deepgram should use a live WebSocket session when available."""
+    from whisprbar.transcription import deepgram as deepgram_module
+
+    created = {}
+
+    class FakeSession:
+        def __init__(self, api_key, url):
+            created["api_key"] = api_key
+            created["url"] = url
+
+    transcriber = DeepgramTranscriber()
+    transcriber.api_key = "test-key"
+    monkeypatch.setattr(transcriber, "ensure_client", lambda: True)
+    monkeypatch.setattr(deepgram_module, "DeepgramRealtimeSession", FakeSession)
+
+    session = transcriber.start_streaming("en")
+
+    assert isinstance(session, FakeSession)
+    assert created["api_key"] == "test-key"
+    assert "language=multi" in created["url"]
+
+
+@pytest.mark.unit
+def test_deepgram_realtime_session_sends_binary_audio_and_finalizes(monkeypatch):
+    """Live sessions should send PCM bytes and finalize before returning text."""
+    sent_payloads = []
+    captured = {}
+
+    class FakeWebSocket:
+        def __init__(self):
+            self._messages = asyncio.Queue()
+
+        async def send(self, payload):
+            sent_payloads.append(payload)
+            if isinstance(payload, str) and json.loads(payload).get("type") == "Finalize":
+                await self._messages.put(
+                    json.dumps(
+                        {
+                            "type": "Results",
+                            "is_final": True,
+                            "from_finalize": True,
+                            "channel": {
+                                "alternatives": [{"transcript": "hallo live"}]
+                            },
+                        }
+                    )
+                )
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            return await self._messages.get()
+
+    class FakeConnect:
+        async def __aenter__(self):
+            return FakeWebSocket()
+
+        async def __aexit__(self, _exc_type, _exc, _tb):
+            return False
+
+    def fake_connect(uri, **kwargs):
+        captured["uri"] = uri
+        captured["kwargs"] = kwargs
+        return FakeConnect()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "websockets",
+        SimpleNamespace(connect=fake_connect),
+    )
+
+    session = DeepgramRealtimeSession("test-key", "wss://api.deepgram.com/v1/listen")
+    session.push_audio(np.array([0.1, 0.2], dtype=np.float32))
+
+    assert session.finish() == "hallo live"
+    assert captured["kwargs"]["additional_headers"]["Authorization"] == "Token test-key"
+    assert any(isinstance(payload, bytes) for payload in sent_payloads)
+    control_messages = [
+        json.loads(payload)["type"]
+        for payload in sent_payloads
+        if isinstance(payload, str)
+    ]
+    assert "Finalize" in control_messages
+    assert "CloseStream" in control_messages
 
 
 @pytest.mark.unit

--- a/tests/test_main_audio_feedback.py
+++ b/tests/test_main_audio_feedback.py
@@ -1,6 +1,7 @@
 """Unit tests for audio feedback flow in whisprbar.main."""
 
 import threading
+import os
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -115,6 +116,182 @@ def test_on_recording_stop_starts_only_one_background_thread_for_transcription(
     main.on_recording_stop()
 
     assert len(created_targets) == 1
+
+
+@pytest.mark.unit
+def test_on_recording_stop_does_not_lower_process_priority(monkeypatch, mock_config):
+    """Transcription must not repeatedly nice() the whole app process."""
+    nice_calls = []
+
+    class ImmediateThread:
+        def __init__(self, target=None, daemon=None, **_kwargs):
+            self._target = target
+
+        def start(self):
+            if self._target is not None:
+                self._target()
+
+    mock_config.update(
+        {
+            "noise_reduction_enabled": False,
+            "auto_paste_enabled": False,
+            "min_audio_energy": 0.0,
+            "live_overlay_display_duration": 0.5,
+            "language": "de",
+        }
+    )
+    config.cfg.clear()
+    config.cfg.update(mock_config)
+
+    monkeypatch.setattr(os, "nice", lambda value: nice_calls.append(value), raising=False)
+    monkeypatch.setattr(main.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(main, "refresh_tray_indicator", lambda _state: None)
+    monkeypatch.setattr(main, "refresh_menu", lambda _callbacks, _state: None)
+    monkeypatch.setattr(main, "get_callbacks", lambda: {})
+    monkeypatch.setattr(main, "notify", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "copy_to_clipboard", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "play_audio_feedback", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        main,
+        "get_recording_state",
+        lambda: {"audio_data": np.ones(SAMPLE_RATE, dtype=np.float32)},
+    )
+    monkeypatch.setattr(main, "transcribe_audio", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "TRANSCRIPTION_SEMAPHORE", threading.Semaphore(2))
+
+    from whisprbar import audio, ui
+    from whisprbar.ui import recording_indicator
+
+    monkeypatch.setattr(audio, "apply_noise_reduction", lambda audio_data: audio_data)
+    monkeypatch.setattr(audio, "apply_vad", lambda audio_data: audio_data)
+    monkeypatch.setattr(ui, "show_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ui, "update_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ui, "hide_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(recording_indicator, "show_recording_indicator", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(recording_indicator, "hide_recording_indicator", lambda *_args, **_kwargs: None)
+
+    main.state.recording = True
+    main.state.transcribing = False
+
+    main.on_recording_stop()
+
+    assert nice_calls == []
+
+
+@pytest.mark.unit
+def test_on_recording_stop_cancels_live_session_when_queue_full(monkeypatch, mock_config):
+    """Dropped transcription requests must not leak an active live session."""
+    cancelled = []
+
+    class FakeSession:
+        def cancel(self):
+            cancelled.append(True)
+
+    class ImmediateThread:
+        def __init__(self, target=None, daemon=None, **_kwargs):
+            self._target = target
+
+        def start(self):
+            if self._target is not None:
+                self._target()
+
+    mock_config.update({"language": "de"})
+    config.cfg.clear()
+    config.cfg.update(mock_config)
+
+    monkeypatch.setattr(main.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(main, "refresh_tray_indicator", lambda _state: None)
+    monkeypatch.setattr(main, "refresh_menu", lambda _callbacks, _state: None)
+    monkeypatch.setattr(main, "get_callbacks", lambda: {})
+    monkeypatch.setattr(main, "notify", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "play_audio_feedback", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        main,
+        "get_recording_state",
+        lambda: {"audio_data": np.ones(SAMPLE_RATE, dtype=np.float32)},
+    )
+    monkeypatch.setattr(main, "TRANSCRIPTION_SEMAPHORE", threading.Semaphore(0))
+    monkeypatch.setattr(main, "_active_live_transcription_session", FakeSession(), raising=False)
+
+    from whisprbar.ui import recording_indicator
+
+    monkeypatch.setattr(recording_indicator, "show_recording_indicator", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(recording_indicator, "hide_recording_indicator", lambda *_args, **_kwargs: None)
+
+    main.state.recording = True
+    main.state.transcribing = False
+
+    main.on_recording_stop()
+
+    assert cancelled == [True]
+    assert main._active_live_transcription_session is None
+
+
+@pytest.mark.unit
+def test_on_recording_stop_skips_noise_reduction_for_live_session(monkeypatch, mock_config):
+    """Live backends have already received raw audio, so NR should not delay stop."""
+    copied = []
+
+    class FakeSession:
+        def finish(self):
+            return "Hallo live"
+
+    class ImmediateTranscriptionThreadOnly:
+        def __init__(self, target=None, daemon=None, **_kwargs):
+            self._target = target
+
+        def start(self):
+            if getattr(self._target, "__name__", "") == "transcribe_thread":
+                self._target()
+
+    mock_config.update(
+        {
+            "noise_reduction_enabled": True,
+            "auto_paste_enabled": False,
+            "min_audio_energy": 0.0,
+            "live_overlay_display_duration": 0.5,
+            "language": "de",
+        }
+    )
+    config.cfg.clear()
+    config.cfg.update(mock_config)
+
+    monkeypatch.setattr(main.threading, "Thread", ImmediateTranscriptionThreadOnly)
+    monkeypatch.setattr(main, "refresh_tray_indicator", lambda _state: None)
+    monkeypatch.setattr(main, "refresh_menu", lambda _callbacks, _state: None)
+    monkeypatch.setattr(main, "get_callbacks", lambda: {})
+    monkeypatch.setattr(main, "notify", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "copy_to_clipboard", lambda text: copied.append(text) or True)
+    monkeypatch.setattr(main, "play_audio_feedback", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "write_history", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        main,
+        "get_recording_state",
+        lambda: {"audio_data": np.ones(SAMPLE_RATE * 9, dtype=np.float32)},
+    )
+    monkeypatch.setattr(main, "TRANSCRIPTION_SEMAPHORE", threading.Semaphore(2))
+    monkeypatch.setattr(main, "_active_live_transcription_session", FakeSession(), raising=False)
+
+    from whisprbar import audio, ui
+    from whisprbar.ui import recording_indicator
+
+    def fail_noise_reduction(_audio_data):
+        raise AssertionError("noise reduction should not run for live sessions")
+
+    monkeypatch.setattr(audio, "apply_noise_reduction", fail_noise_reduction)
+    monkeypatch.setattr(audio, "apply_vad", lambda audio_data: audio_data)
+    monkeypatch.setattr(ui, "show_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ui, "update_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ui, "hide_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(recording_indicator, "show_recording_indicator", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(recording_indicator, "hide_recording_indicator", lambda *_args, **_kwargs: None)
+
+    main.state.recording = True
+    main.state.transcribing = False
+
+    main.on_recording_stop()
+
+    assert copied == ["Hallo live"]
 
 
 @pytest.mark.unit

--- a/tests/test_main_audio_feedback.py
+++ b/tests/test_main_audio_feedback.py
@@ -182,8 +182,13 @@ def test_on_recording_stop_does_not_lower_process_priority(monkeypatch, mock_con
 def test_on_recording_stop_cancels_live_session_when_queue_full(monkeypatch, mock_config):
     """Dropped transcription requests must not leak an active live session."""
     cancelled = []
+    finished = []
 
     class FakeSession:
+        def finish(self):
+            finished.append(True)
+            return "should not finish"
+
         def cancel(self):
             cancelled.append(True)
 
@@ -222,6 +227,331 @@ def test_on_recording_stop_cancels_live_session_when_queue_full(monkeypatch, moc
     main.state.transcribing = False
 
     main.on_recording_stop()
+
+    assert cancelled == [True]
+    assert finished == []
+    assert main._active_live_transcription_session is None
+
+
+@pytest.mark.unit
+def test_on_recording_stop_claims_live_session_before_publishing_idle(monkeypatch, mock_config):
+    """A stopped recording must own its live session even if another recording starts."""
+    copied = []
+    deferred_transcribe = []
+    finished = []
+
+    class FakeSession:
+        def __init__(self, name):
+            self.name = name
+            self.cancelled = False
+
+        def finish(self):
+            finished.append(self.name)
+            return f"{self.name} transcript"
+
+        def cancel(self):
+            self.cancelled = True
+
+    class ControlledThread:
+        def __init__(self, target=None, daemon=None, **_kwargs):
+            self._target = target
+            self.daemon = daemon
+
+        def start(self):
+            if getattr(self._target, "__name__", "") == "transcribe_thread":
+                deferred_transcribe.append(self._target)
+            elif self._target is not None:
+                self._target()
+
+        def join(self, timeout=None):
+            return None
+
+        def is_alive(self):
+            return False
+
+    mock_config.update(
+        {
+            "noise_reduction_enabled": False,
+            "auto_paste_enabled": False,
+            "min_audio_energy": 0.0,
+            "live_overlay_display_duration": 0.5,
+            "language": "de",
+        }
+    )
+    config.cfg.clear()
+    config.cfg.update(mock_config)
+
+    session_a = FakeSession("first")
+    session_b = FakeSession("second")
+
+    class RaceState:
+        def __init__(self):
+            self._recording = True
+            self.transcribing = False
+            self.last_transcript = ""
+
+        @property
+        def recording(self):
+            return self._recording
+
+        @recording.setter
+        def recording(self, value):
+            self._recording = value
+            if value is False:
+                main._active_live_transcription_session = session_b
+
+        def get(self, key, default=None):
+            return getattr(self, key, default)
+
+        def __getitem__(self, key):
+            return getattr(self, key)
+
+        def __setitem__(self, key, value):
+            setattr(self, key, value)
+
+    monkeypatch.setattr(main.threading, "Thread", ControlledThread)
+    monkeypatch.setattr(main, "refresh_tray_indicator", lambda _state: None)
+    monkeypatch.setattr(main, "refresh_menu", lambda _callbacks, _state: None)
+    monkeypatch.setattr(main, "get_callbacks", lambda: {})
+    monkeypatch.setattr(main, "notify", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "copy_to_clipboard", lambda text: copied.append(text) or True)
+    monkeypatch.setattr(main, "play_audio_feedback", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "write_history", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        main,
+        "get_recording_state",
+        lambda: {"audio_data": np.ones(SAMPLE_RATE, dtype=np.float32)},
+    )
+    monkeypatch.setattr(main, "transcribe_audio", lambda *_args, **_kwargs: "batch")
+    monkeypatch.setattr(main, "TRANSCRIPTION_SEMAPHORE", threading.Semaphore(2))
+    monkeypatch.setattr(main, "_active_live_transcription_session", session_a, raising=False)
+    monkeypatch.setattr(main, "state", RaceState())
+
+    from whisprbar import audio, ui
+    from whisprbar.ui import recording_indicator
+
+    monkeypatch.setattr(audio, "apply_noise_reduction", lambda audio_data: audio_data)
+    monkeypatch.setattr(audio, "apply_vad", lambda audio_data: audio_data)
+    monkeypatch.setattr(ui, "show_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ui, "update_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ui, "hide_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(recording_indicator, "show_recording_indicator", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(recording_indicator, "hide_recording_indicator", lambda *_args, **_kwargs: None)
+
+    main.on_recording_stop()
+    assert deferred_transcribe
+
+    deferred_transcribe[0]()
+
+    assert finished == ["first"]
+    assert copied == ["First transcript"]
+    assert main._active_live_transcription_session is session_b
+    assert session_b.cancelled is False
+
+
+@pytest.mark.unit
+def test_on_recording_stop_without_live_session_does_not_claim_new_recording(monkeypatch, mock_config):
+    """A batch-only stopped recording must not steal a later recording's live session."""
+    copied = []
+    deferred_transcribe = []
+    finished = []
+    cancelled = []
+
+    class NewRecordingSession:
+        def finish(self):
+            finished.append(True)
+            return "new recording transcript"
+
+        def cancel(self):
+            cancelled.append(True)
+
+    session_b = NewRecordingSession()
+
+    class RaceState:
+        def __init__(self):
+            self._recording = True
+            self.transcribing = False
+            self.last_transcript = ""
+
+        @property
+        def recording(self):
+            return self._recording
+
+        @recording.setter
+        def recording(self, value):
+            self._recording = value
+            if value is False:
+                main._active_live_transcription_session = session_b
+
+        def get(self, key, default=None):
+            return getattr(self, key, default)
+
+        def __getitem__(self, key):
+            return getattr(self, key)
+
+        def __setitem__(self, key, value):
+            setattr(self, key, value)
+
+    class ControlledThread:
+        def __init__(self, target=None, daemon=None, **_kwargs):
+            self._target = target
+            self.daemon = daemon
+
+        def start(self):
+            if getattr(self._target, "__name__", "") == "transcribe_thread":
+                deferred_transcribe.append(self._target)
+            elif self._target is not None:
+                self._target()
+
+        def join(self, timeout=None):
+            return None
+
+        def is_alive(self):
+            return False
+
+    mock_config.update(
+        {
+            "noise_reduction_enabled": False,
+            "auto_paste_enabled": False,
+            "min_audio_energy": 0.0,
+            "live_overlay_display_duration": 0.5,
+            "language": "de",
+        }
+    )
+    config.cfg.clear()
+    config.cfg.update(mock_config)
+
+    monkeypatch.setattr(main.threading, "Thread", ControlledThread)
+    monkeypatch.setattr(main, "refresh_tray_indicator", lambda _state: None)
+    monkeypatch.setattr(main, "refresh_menu", lambda _callbacks, _state: None)
+    monkeypatch.setattr(main, "get_callbacks", lambda: {})
+    monkeypatch.setattr(main, "notify", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "copy_to_clipboard", lambda text: copied.append(text) or True)
+    monkeypatch.setattr(main, "play_audio_feedback", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "write_history", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        main,
+        "get_recording_state",
+        lambda: {"audio_data": np.ones(SAMPLE_RATE, dtype=np.float32)},
+    )
+    monkeypatch.setattr(main, "transcribe_audio", lambda *_args, **_kwargs: "batch transcript")
+    monkeypatch.setattr(main, "TRANSCRIPTION_SEMAPHORE", threading.Semaphore(2))
+    monkeypatch.setattr(main, "_active_live_transcription_session", None, raising=False)
+    monkeypatch.setattr(main, "state", RaceState())
+
+    from whisprbar import audio, ui
+    from whisprbar.ui import recording_indicator
+
+    monkeypatch.setattr(audio, "apply_noise_reduction", lambda audio_data: audio_data)
+    monkeypatch.setattr(audio, "apply_vad", lambda audio_data: audio_data)
+    monkeypatch.setattr(ui, "show_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ui, "update_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ui, "hide_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(recording_indicator, "show_recording_indicator", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(recording_indicator, "hide_recording_indicator", lambda *_args, **_kwargs: None)
+
+    main.on_recording_stop()
+    deferred_transcribe[0]()
+
+    assert copied == ["Batch transcript"]
+    assert finished == []
+    assert cancelled == []
+    assert main._active_live_transcription_session is session_b
+
+
+@pytest.mark.unit
+def test_live_finish_cancels_session_after_finish_error(monkeypatch):
+    """A failed live finish must clean up backend resources before batch fallback."""
+    cancelled = []
+
+    class FailingSession:
+        def finish(self):
+            raise RuntimeError("backend failed")
+
+        def cancel(self):
+            cancelled.append(True)
+
+    class ImmediateThread:
+        def __init__(self, target=None, daemon=None, **_kwargs):
+            self._target = target
+            self.daemon = daemon
+
+        def start(self):
+            if self._target is not None:
+                self._target()
+
+        def join(self, timeout=None):
+            return None
+
+        def is_alive(self):
+            return False
+
+    monkeypatch.setattr(main.threading, "Thread", ImmediateThread)
+
+    live_finish = main._LiveTranscriptionFinish(FailingSession())
+    text, _elapsed_ms = live_finish.result()
+
+    assert text is None
+    assert cancelled == [True]
+
+
+@pytest.mark.unit
+def test_live_finish_cancels_session_after_timeout(monkeypatch):
+    """A timed-out live finish must not leave a backend worker running."""
+    cancelled = []
+
+    class SlowSession:
+        def finish(self):
+            raise AssertionError("finish thread should be deferred by this test")
+
+        def cancel(self):
+            cancelled.append(True)
+
+    class DeferredThread:
+        def __init__(self, target=None, daemon=None, **_kwargs):
+            self._target = target
+            self.daemon = daemon
+
+        def start(self):
+            return None
+
+        def join(self, timeout=None):
+            return None
+
+        def is_alive(self):
+            return True
+
+    monkeypatch.setattr(main.threading, "Thread", DeferredThread)
+
+    live_finish = main._LiveTranscriptionFinish(SlowSession())
+    text, _elapsed_ms = live_finish.result(timeout=0.0)
+
+    assert text is None
+    assert cancelled == [True]
+
+
+@pytest.mark.unit
+def test_start_recording_hotkey_cancels_live_session_when_start_fails(monkeypatch):
+    """A stream startup failure after live startup must not leak a realtime session."""
+    cancelled = []
+
+    class FakeSession:
+        def cancel(self):
+            cancelled.append(True)
+
+    monkeypatch.setattr(
+        main,
+        "start_recording",
+        lambda: (_ for _ in ()).throw(RuntimeError("stream failed")),
+    )
+    monkeypatch.setattr(main, "notify", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "refresh_tray_indicator", lambda _state: None)
+    monkeypatch.setattr(main, "_active_live_transcription_session", FakeSession(), raising=False)
+
+    main.state.recording = False
+    main.state.transcribing = False
+
+    main.start_recording_hotkey()
 
     assert cancelled == [True]
     assert main._active_live_transcription_session is None

--- a/tests/test_main_audio_feedback.py
+++ b/tests/test_main_audio_feedback.py
@@ -241,7 +241,7 @@ def test_on_recording_stop_skips_noise_reduction_for_live_session(monkeypatch, m
             self._target = target
 
         def start(self):
-            if getattr(self._target, "__name__", "") == "transcribe_thread":
+            if getattr(self._target, "__name__", "") in {"transcribe_thread", "live_finish_thread"}:
                 self._target()
 
     mock_config.update(
@@ -292,6 +292,81 @@ def test_on_recording_stop_skips_noise_reduction_for_live_session(monkeypatch, m
     main.on_recording_stop()
 
     assert copied == ["Hallo live"]
+
+
+@pytest.mark.unit
+def test_on_recording_stop_starts_live_finish_before_vad(monkeypatch, mock_config):
+    """Live ASR finalization should overlap local audio processing after stop."""
+    order = []
+
+    class FakeSession:
+        def finish(self):
+            order.append("finish")
+            return None
+
+        def cancel(self):
+            order.append("cancel")
+
+    class ImmediateThread:
+        def __init__(self, target=None, daemon=None, **_kwargs):
+            self._target = target
+            self.daemon = daemon
+
+        def start(self):
+            if self._target is not None:
+                self._target()
+
+        def join(self, timeout=None):
+            return None
+
+        def is_alive(self):
+            return False
+
+    mock_config.update(
+        {
+            "noise_reduction_enabled": False,
+            "auto_paste_enabled": False,
+            "min_audio_energy": 0.0,
+            "live_overlay_display_duration": 0.5,
+            "language": "de",
+        }
+    )
+    config.cfg.clear()
+    config.cfg.update(mock_config)
+
+    monkeypatch.setattr(main.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(main, "refresh_tray_indicator", lambda _state: None)
+    monkeypatch.setattr(main, "refresh_menu", lambda _callbacks, _state: None)
+    monkeypatch.setattr(main, "get_callbacks", lambda: {})
+    monkeypatch.setattr(main, "notify", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "copy_to_clipboard", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "play_audio_feedback", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        main,
+        "get_recording_state",
+        lambda: {"audio_data": np.ones(SAMPLE_RATE, dtype=np.float32)},
+    )
+    monkeypatch.setattr(main, "transcribe_audio", lambda *_args, **_kwargs: order.append("batch") or None)
+    monkeypatch.setattr(main, "TRANSCRIPTION_SEMAPHORE", threading.Semaphore(2))
+    monkeypatch.setattr(main, "_active_live_transcription_session", FakeSession(), raising=False)
+
+    from whisprbar import audio, ui
+    from whisprbar.ui import recording_indicator
+
+    monkeypatch.setattr(audio, "apply_noise_reduction", lambda audio_data: audio_data)
+    monkeypatch.setattr(audio, "apply_vad", lambda audio_data: order.append("vad") or audio_data)
+    monkeypatch.setattr(ui, "show_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ui, "update_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ui, "hide_live_overlay", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(recording_indicator, "show_recording_indicator", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(recording_indicator, "hide_recording_indicator", lambda *_args, **_kwargs: None)
+
+    main.state.recording = True
+    main.state.transcribing = False
+
+    main.on_recording_stop()
+
+    assert order[:2] == ["finish", "vad"]
 
 
 @pytest.mark.unit

--- a/tests/test_main_flow_integration.py
+++ b/tests/test_main_flow_integration.py
@@ -178,8 +178,8 @@ def test_dispatch_transcript_shows_paste_before_done(monkeypatch):
 
 
 @pytest.mark.unit
-def test_transcribe_processed_audio_prefers_active_live_session(monkeypatch):
-    """Stop processing should finish an active streaming session before batch ASR."""
+def test_transcribe_processed_audio_prefers_claimed_live_session(monkeypatch):
+    """Stop processing should finish its claimed streaming session before batch ASR."""
     from whisprbar import main
 
     class FakeSession:
@@ -192,15 +192,17 @@ def test_transcribe_processed_audio_prefers_active_live_session(monkeypatch):
 
     session = FakeSession()
     monkeypatch.setattr(main, "_active_live_transcription_session", session, raising=False)
+    live_finish = main._start_live_transcription_finish()
 
     def fail_batch(_processed, _language):
-        raise AssertionError("batch transcription should not run when live session is active")
+        raise AssertionError("batch transcription should not run when live session has text")
 
     monkeypatch.setattr(main, "transcribe_audio", fail_batch)
 
     text, elapsed_ms = main._transcribe_processed_audio(
         np.ones(16000, dtype=np.float32),
         "en",
+        live_finish=live_finish,
     )
 
     assert text == "live transcript"

--- a/tests/test_main_flow_integration.py
+++ b/tests/test_main_flow_integration.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 from whisprbar.flow.models import FlowOutput, PastePolicy
@@ -77,6 +78,40 @@ def test_dispatch_transcript_persists_analysis_record(monkeypatch):
 
 
 @pytest.mark.unit
+def test_dispatch_transcript_persists_latency_metadata(monkeypatch):
+    from whisprbar import main
+
+    monotonic_values = iter([10.0, 10.125, 20.0, 20.01])
+    flow_output = FlowOutput(
+        raw_text="raw text",
+        final_text="Final text",
+        profile_id="default",
+        metadata={"raw_text": "raw text"},
+    )
+    mock_store = MagicMock()
+
+    monkeypatch.setattr(main.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(main, "process_flow_text", lambda text, language, cfg: flow_output)
+    monkeypatch.setattr(main, "write_history", MagicMock())
+    monkeypatch.setattr(main, "save_transcript_record", mock_store, raising=False)
+    monkeypatch.setattr(main, "copy_to_clipboard", MagicMock(return_value=True))
+    main.cfg["auto_paste_enabled"] = False
+    main.cfg["language"] = "en"
+
+    main.dispatch_transcript_text(
+        "raw text",
+        output_seconds=1.0,
+        runtime_metadata={"transcribe_ms": 42.0, "audio_process_ms": 12.5},
+    )
+
+    metadata = mock_store.call_args.kwargs["metadata"]
+    assert metadata["flow_ms"] == pytest.approx(125.0)
+    assert metadata["paste_ms"] == pytest.approx(10.0)
+    assert metadata["transcribe_ms"] == 42.0
+    assert metadata["audio_process_ms"] == 12.5
+
+
+@pytest.mark.unit
 def test_dispatch_transcript_copies_when_auto_paste_disabled(monkeypatch):
     from whisprbar import main
 
@@ -140,3 +175,85 @@ def test_dispatch_transcript_shows_paste_before_done(monkeypatch):
     )
 
     assert [phase for phase, _info in phases] == ["pasting", "complete"]
+
+
+@pytest.mark.unit
+def test_transcribe_processed_audio_prefers_active_live_session(monkeypatch):
+    """Stop processing should finish an active streaming session before batch ASR."""
+    from whisprbar import main
+
+    class FakeSession:
+        def __init__(self):
+            self.finished = False
+
+        def finish(self):
+            self.finished = True
+            return "live transcript"
+
+    session = FakeSession()
+    monkeypatch.setattr(main, "_active_live_transcription_session", session, raising=False)
+
+    def fail_batch(_processed, _language):
+        raise AssertionError("batch transcription should not run when live session is active")
+
+    monkeypatch.setattr(main, "transcribe_audio", fail_batch)
+
+    text, elapsed_ms = main._transcribe_processed_audio(
+        np.ones(16000, dtype=np.float32),
+        "en",
+    )
+
+    assert text == "live transcript"
+    assert elapsed_ms >= 0
+    assert session.finished is True
+    assert main._active_live_transcription_session is None
+
+
+@pytest.mark.unit
+def test_start_live_transcription_session_stores_backend_session(monkeypatch):
+    """Recording start should create a live session when the backend supports it."""
+    from whisprbar import main
+
+    class FakeSession:
+        pass
+
+    class FakeTranscriber:
+        def __init__(self):
+            self.languages = []
+
+        def start_streaming(self, language):
+            self.languages.append(language)
+            return session
+
+    session = FakeSession()
+    transcriber = FakeTranscriber()
+    monkeypatch.setattr(main, "get_transcriber", lambda: transcriber)
+    monkeypatch.setitem(main.cfg, "language", "en")
+    monkeypatch.setattr(main, "_active_live_transcription_session", None, raising=False)
+
+    main._start_live_transcription_session()
+
+    assert transcriber.languages == ["en"]
+    assert main._active_live_transcription_session is session
+
+
+@pytest.mark.unit
+def test_push_live_audio_chunk_forwards_to_active_session(monkeypatch):
+    """Captured audio frames should be sent to the active live backend session."""
+    from whisprbar import main
+
+    received = []
+
+    class FakeSession:
+        def push_audio(self, audio):
+            received.append(audio)
+
+    frame = np.array([[0.1], [0.2], [0.3]], dtype=np.float32)
+    session = FakeSession()
+    monkeypatch.setattr(main, "_active_live_transcription_session", session, raising=False)
+
+    main._push_live_audio_chunk(frame)
+
+    assert len(received) == 1
+    np.testing.assert_array_equal(received[0], np.array([0.1, 0.2, 0.3], dtype=np.float32))
+    assert received[0] is not frame

--- a/tests/test_paste.py
+++ b/tests/test_paste.py
@@ -27,11 +27,11 @@ def test_get_paste_delay_seconds_default(mock_config):
     """Test get_paste_delay_seconds with default value."""
     from whisprbar import config
 
-    mock_config["paste_delay_ms"] = 250
+    mock_config["paste_delay_ms"] = 0
     paste.cfg = mock_config
 
     delay = paste.get_paste_delay_seconds()
-    assert delay == 0.25
+    assert delay == 0.0
 
 
 @pytest.mark.unit

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,6 +1,9 @@
 """Tests for project packaging metadata."""
 
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    import tomli as tomllib
 from pathlib import Path
 
 from whisprbar import __version__

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -14,3 +14,13 @@ def test_pyproject_version_matches_package_version():
     metadata = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
     assert metadata["project"]["version"] == __version__
+
+
+def test_pyproject_python_floor_matches_syntax_usage():
+    """Package metadata should not advertise unsupported Python versions."""
+    metadata = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    classifiers = set(metadata["project"]["classifiers"])
+
+    assert metadata["project"]["requires-python"] == ">=3.10"
+    assert "Programming Language :: Python :: 3.8" not in classifiers
+    assert "Programming Language :: Python :: 3.9" not in classifiers

--- a/tests/test_settings_webview.py
+++ b/tests/test_settings_webview.py
@@ -357,7 +357,7 @@ def test_generate_settings_html_adds_numeric_bounds_and_units():
         snippets=[],
     )
 
-    assert 'name="paste_delay_ms" value="250" min="0" max="5000" step="50"' in html
+    assert 'name="paste_delay_ms" value="0" min="0" max="5000" step="50"' in html
     assert '<span class="wb-unit">ms</span>' in html
     assert 'name="recording_indicator_opacity" value="0.85" min="0.3" max="1" step="0.05"' in html
     assert '<span class="wb-unit">px</span>' in html

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -407,3 +407,43 @@ def test_elevenlabs_realtime_session_discards_partial_text_after_queue_overflow(
     session.push_audio(np.ones(1, dtype=np.float32))
 
     assert session.finish() is None
+
+
+@pytest.mark.unit
+def test_elevenlabs_realtime_session_discards_partial_text_when_close_drops_audio(monkeypatch):
+    """A full queue at finish means the sentinel displaced live audio."""
+    from whisprbar.transcription.elevenlabs import ElevenLabsRealtimeSession
+
+    monkeypatch.setattr(ElevenLabsRealtimeSession, "_run_thread", lambda self: None)
+    session = ElevenLabsRealtimeSession(object(), "en")
+    session._result_parts.append("partial live text")
+
+    while not session._audio_queue.full():
+        session._audio_queue.put_nowait(np.ones(1, dtype=np.float32))
+
+    assert session.finish() is None
+
+
+@pytest.mark.unit
+def test_elevenlabs_realtime_session_cancels_worker_after_finish_timeout(monkeypatch):
+    """Timed-out realtime workers should be cancelled before batch fallback."""
+    from whisprbar.transcription.elevenlabs import ElevenLabsRealtimeSession
+
+    monkeypatch.setattr(ElevenLabsRealtimeSession, "_run_thread", lambda self: None)
+    session = ElevenLabsRealtimeSession(object(), "en")
+    joins = []
+    cancelled = []
+
+    class HungThread:
+        def join(self, timeout=None):
+            joins.append(timeout)
+
+        def is_alive(self):
+            return True
+
+    session._thread = HungThread()
+    monkeypatch.setattr(session, "cancel", lambda: cancelled.append(True))
+
+    assert session.finish() is None
+    assert joins == [15.0]
+    assert cancelled == [True]

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,5 +1,8 @@
 """Unit tests for whisprbar.transcription module."""
 
+import base64
+import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
@@ -276,3 +279,114 @@ def test_streaming_transcriber_supports_streaming():
     """Test that StreamingTranscriber.supports_streaming() returns True."""
     transcriber = transcription.StreamingTranscriber()
     assert transcriber.supports_streaming() is True
+
+
+@pytest.mark.unit
+def test_transcriber_start_streaming_default_none():
+    """Batch-only backends should opt out of live streaming by default."""
+
+    class DummyTranscriber(transcription.Transcriber):
+        def transcribe(self, audio, language="de"):
+            return None
+
+        def get_name(self):
+            return "Dummy"
+
+    transcriber = DummyTranscriber()
+
+    assert transcriber.start_streaming("de") is None
+
+
+@pytest.mark.unit
+def test_elevenlabs_start_streaming_creates_live_session(monkeypatch):
+    """ElevenLabs should expose a live session without doing batch transcription."""
+    from whisprbar.transcription import elevenlabs as elevenlabs_module
+
+    created = {}
+
+    class FakeSession:
+        def __init__(self, client, language):
+            created["client"] = client
+            created["language"] = language
+
+    client = object()
+    transcriber = transcription.ElevenLabsTranscriber()
+    transcriber.client = client
+    monkeypatch.setattr(transcriber, "ensure_client", lambda: True)
+    monkeypatch.setattr(elevenlabs_module, "ElevenLabsRealtimeSession", FakeSession)
+
+    session = transcriber.start_streaming("en")
+
+    assert isinstance(session, FakeSession)
+    assert created == {"client": client, "language": "en"}
+
+
+@pytest.mark.unit
+def test_elevenlabs_audio_chunk_to_base64_encodes_pcm16():
+    """Realtime audio chunks should be clipped and encoded as PCM16."""
+    from whisprbar.transcription.elevenlabs import _audio_chunk_to_base64
+
+    encoded = _audio_chunk_to_base64(
+        np.array([-1.0, 0.0, 0.5, 1.0, 2.0], dtype=np.float32)
+    )
+
+    pcm16 = np.frombuffer(base64.b64decode(encoded), dtype=np.int16)
+    assert pcm16.tolist() == [-32767, 0, 16383, 32767, 32767]
+
+
+@pytest.mark.unit
+def test_elevenlabs_realtime_session_sends_chunks_and_commits(monkeypatch):
+    """Live sessions should send pushed audio before committing on finish."""
+    from whisprbar.transcription.elevenlabs import ElevenLabsRealtimeSession
+
+    sent_payloads = []
+    committed = []
+    closed = []
+
+    class FakeRealtimeAudioOptions:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeConnection:
+        def __init__(self):
+            self.handlers = {}
+
+        def on(self, event, callback):
+            self.handlers[event] = callback
+
+        async def send(self, payload):
+            sent_payloads.append(payload)
+
+        async def commit(self):
+            committed.append(True)
+            self.handlers["committed"]({"text": "hello live"})
+
+        async def close(self):
+            closed.append(True)
+
+    connection = FakeConnection()
+
+    class FakeRealtime:
+        async def connect(self, _options):
+            return connection
+
+    client = SimpleNamespace(
+        speech_to_text=SimpleNamespace(realtime=FakeRealtime())
+    )
+    fake_elevenlabs = SimpleNamespace(
+        AudioFormat=SimpleNamespace(PCM_16000="pcm_16000"),
+        CommitStrategy=SimpleNamespace(MANUAL="manual"),
+        RealtimeAudioOptions=FakeRealtimeAudioOptions,
+        RealtimeEvents=SimpleNamespace(COMMITTED_TRANSCRIPT="committed"),
+    )
+    monkeypatch.setitem(sys.modules, "elevenlabs", fake_elevenlabs)
+
+    session = ElevenLabsRealtimeSession(client, "en")
+    session.push_audio(np.array([0.1, 0.2], dtype=np.float32))
+
+    assert session.finish() == "hello live"
+    assert sent_payloads
+    assert sent_payloads[0]["sample_rate"] == 16000
+    assert sent_payloads[0]["audio_base_64"]
+    assert committed == [True]
+    assert closed == [True]

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -390,3 +390,20 @@ def test_elevenlabs_realtime_session_sends_chunks_and_commits(monkeypatch):
     assert sent_payloads[0]["audio_base_64"]
     assert committed == [True]
     assert closed == [True]
+
+
+@pytest.mark.unit
+def test_elevenlabs_realtime_session_discards_partial_text_after_queue_overflow(monkeypatch):
+    """Dropped live audio chunks must force batch fallback instead of returning partial text."""
+    from whisprbar.transcription.elevenlabs import ElevenLabsRealtimeSession
+
+    monkeypatch.setattr(ElevenLabsRealtimeSession, "_run_thread", lambda self: None)
+    session = ElevenLabsRealtimeSession(object(), "en")
+    session._result_parts.append("partial live text")
+
+    while not session._audio_queue.full():
+        session._audio_queue.put_nowait(np.ones(1, dtype=np.float32))
+
+    session.push_audio(np.ones(1, dtype=np.float32))
+
+    assert session.finish() is None

--- a/whisprbar/audio/recorder.py
+++ b/whisprbar/audio/recorder.py
@@ -27,13 +27,18 @@ recording_state = {
     "device_idx": None,
     "audio_data": None,
     "generation": 0,
+    "started_at_monotonic": None,
+    "first_audio_at_monotonic": None,
+    "stopped_at_monotonic": None,
 }
 
 # Callbacks for recording events
 _recording_callbacks = {
+    "on_before_start": None,
     "on_start": None,
     "on_stop": None,
     "on_audio_level": None,
+    "on_audio_chunk": None,
 }
 
 # Lazy-loaded sounddevice module (import can block/fail in headless CI)
@@ -207,6 +212,9 @@ def recording_callback(indata, frames, time_info, status):
         if queue_obj is not None:
             try:
                 queue_obj.put_nowait(data_copy)
+                with _recording_state_lock:
+                    if recording_state.get("first_audio_at_monotonic") is None:
+                        recording_state["first_audio_at_monotonic"] = time.monotonic()
             except queue.Full:
                 # Should never happen with unbounded queue, but handle defensively
                 print("[ERROR] Audio queue unexpectedly full, dropping frame", file=sys.stderr)
@@ -220,6 +228,13 @@ def recording_callback(indata, frames, time_info, status):
             _recording_callbacks["on_audio_level"](level)
         except Exception:
             pass
+
+    # Feed live transcription sessions without blocking local recording.
+    if _recording_callbacks.get("on_audio_chunk"):
+        try:
+            _recording_callbacks["on_audio_chunk"](data_copy)
+        except Exception as exc:
+            debug(f"Audio chunk callback error: {exc}")
 
     # Also feed to VAD monitor queue if it exists
     from .vad import vad_monitor_lock, VAD_MONITOR_QUEUE
@@ -280,6 +295,19 @@ def start_recording() -> None:
             dtype="float32",
             device=device_idx,
         )
+
+        # Prepare live consumers before sounddevice can emit the first frame.
+        if _recording_callbacks.get("on_before_start"):
+            try:
+                _recording_callbacks["on_before_start"]()
+            except Exception as exc:
+                debug(f"Recording before-start callback error: {exc}")
+
+        with _recording_state_lock:
+            recording_state["started_at_monotonic"] = time.monotonic()
+            recording_state["first_audio_at_monotonic"] = None
+            recording_state["stopped_at_monotonic"] = None
+
         stream.start()
         with _recording_state_lock:
             recording_state["stream"] = stream
@@ -333,6 +361,7 @@ def stop_recording() -> Optional[np.ndarray]:
         if not recording_state.get("recording"):
             return None
         recording_state["recording"] = False
+        recording_state["stopped_at_monotonic"] = time.monotonic()
         stream = recording_state.get("stream")
 
     with audio_queue_lock:
@@ -342,7 +371,7 @@ def stop_recording() -> Optional[np.ndarray]:
 
     # Calculate single unified grace period for queue draining
     # This is the time we wait after stopping the stream for buffered audio to arrive
-    grace_ms = max(100, min(2000, int(cfg.get("stop_tail_grace_ms", 500))))
+    grace_ms = max(100, min(2000, int(cfg.get("stop_tail_grace_ms", 200))))
     grace_seconds = grace_ms / 1000.0
 
     # Minimum drain timeout (configurable, default 100ms for fast response)
@@ -420,17 +449,27 @@ def stop_recording() -> Optional[np.ndarray]:
 # Callback Management
 # =============================================================================
 
-def set_recording_callbacks(on_start=None, on_stop=None, on_audio_level=None):
+def set_recording_callbacks(
+    on_start=None,
+    on_stop=None,
+    on_audio_level=None,
+    on_audio_chunk=None,
+    on_before_start=None,
+):
     """Set callbacks for recording events.
 
     Args:
+        on_before_start: Function to call immediately before the input stream starts
         on_start: Function to call when recording starts
         on_stop: Function to call when recording stops
         on_audio_level: Function(float) called per audio frame with level 0.0-1.0
+        on_audio_chunk: Function(np.ndarray) called per captured audio frame
     """
+    _recording_callbacks["on_before_start"] = on_before_start
     _recording_callbacks["on_start"] = on_start
     _recording_callbacks["on_stop"] = on_stop
     _recording_callbacks["on_audio_level"] = on_audio_level
+    _recording_callbacks["on_audio_chunk"] = on_audio_chunk
 
 
 def get_recording_state() -> dict:

--- a/whisprbar/audio/recorder.py
+++ b/whisprbar/audio/recorder.py
@@ -8,7 +8,7 @@ import queue
 import sys
 import threading
 import time
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import numpy as np
 
@@ -207,17 +207,21 @@ def recording_callback(indata, frames, time_info, status):
 
     # Use non-blocking put to prevent callback thread blocking (defensive programming)
     # Queue is unbounded so this should never raise queue.Full, but we handle it anyway
+    queued = False
     with audio_queue_lock:
         queue_obj = AUDIO_QUEUE
         if queue_obj is not None:
             try:
                 queue_obj.put_nowait(data_copy)
-                with _recording_state_lock:
-                    if recording_state.get("first_audio_at_monotonic") is None:
-                        recording_state["first_audio_at_monotonic"] = time.monotonic()
+                queued = True
             except queue.Full:
                 # Should never happen with unbounded queue, but handle defensively
                 print("[ERROR] Audio queue unexpectedly full, dropping frame", file=sys.stderr)
+
+    if queued:
+        with _recording_state_lock:
+            if recording_state.get("first_audio_at_monotonic") is None:
+                recording_state["first_audio_at_monotonic"] = time.monotonic()
 
     # Feed audio level to recording indicator
     if _recording_callbacks.get("on_audio_level"):
@@ -450,12 +454,12 @@ def stop_recording() -> Optional[np.ndarray]:
 # =============================================================================
 
 def set_recording_callbacks(
-    on_start=None,
-    on_stop=None,
-    on_audio_level=None,
-    on_audio_chunk=None,
-    on_before_start=None,
-):
+    on_start: Optional[Callable[[], None]] = None,
+    on_stop: Optional[Callable[[], None]] = None,
+    on_audio_level: Optional[Callable[[float], None]] = None,
+    on_audio_chunk: Optional[Callable[[np.ndarray], None]] = None,
+    on_before_start: Optional[Callable[[], None]] = None,
+) -> None:
     """Set callbacks for recording events.
 
     Args:

--- a/whisprbar/config.py
+++ b/whisprbar/config.py
@@ -42,7 +42,7 @@ DEFAULT_CFG = {
     "auto_paste_add_newline": True,  # Add newline after each transcription
     "auto_paste_add_space": True,  # Add trailing space after pasted text
     "paste_sequence": "auto",
-    "paste_delay_ms": 250,
+    "paste_delay_ms": 0,
     "use_vad": True,  # Enabled by default for better quality
     "vad_energy_ratio": 0.05,  # Increased for better pause handling
     "vad_bridge_ms": 300,  # Increased to bridge natural speech pauses
@@ -77,7 +77,7 @@ DEFAULT_CFG = {
     "faster_whisper_device": "cpu",  # Device: cpu, cuda, rocm
     "faster_whisper_compute_type": "int8",  # Compute type: int8, float16, float32
     "streaming_model": "tiny",  # sherpa-onnx model: tiny, base, small, medium
-    "stop_tail_grace_ms": 500,
+    "stop_tail_grace_ms": 200,
     "min_drain_timeout_ms": 100,  # Minimum drain timeout (100-500ms, default: 100ms for fast response)
     "first_run_complete": False,
     "check_updates": True,

--- a/whisprbar/config_types.py
+++ b/whisprbar/config_types.py
@@ -35,7 +35,7 @@ class AudioConfig:
     min_audio_energy: float = 0.0008
     audio_feedback_enabled: bool = True
     audio_feedback_volume: float = 0.3
-    stop_tail_grace_ms: int = 500
+    stop_tail_grace_ms: int = 200
     min_drain_timeout_ms: int = 100
 
     def validated(self) -> "AudioConfig":
@@ -103,7 +103,7 @@ class PasteConfig:
     auto_paste_add_newline: bool = True
     auto_paste_add_space: bool = True
     paste_sequence: str = "auto"
-    paste_delay_ms: int = 250
+    paste_delay_ms: int = 0
 
     def validated(self) -> "PasteConfig":
         """Return a new PasteConfig with values clamped to safe ranges."""
@@ -295,7 +295,7 @@ class AppConfig:
             min_audio_energy=_get("min_audio_energy", 0.0008),
             audio_feedback_enabled=_get("audio_feedback_enabled", True),
             audio_feedback_volume=_get("audio_feedback_volume", 0.3),
-            stop_tail_grace_ms=_get("stop_tail_grace_ms", 500),
+            stop_tail_grace_ms=_get("stop_tail_grace_ms", 200),
             min_drain_timeout_ms=_get("min_drain_timeout_ms", 100),
         )
 
@@ -327,7 +327,7 @@ class AppConfig:
             auto_paste_add_newline=_get("auto_paste_add_newline", True),
             auto_paste_add_space=_get("auto_paste_add_space", True),
             paste_sequence=_get("paste_sequence", "auto"),
-            paste_delay_ms=_get("paste_delay_ms", 250),
+            paste_delay_ms=_get("paste_delay_ms", 0),
         )
 
         hotkeys_dict = _get("hotkeys", {

--- a/whisprbar/main.py
+++ b/whisprbar/main.py
@@ -36,7 +36,7 @@ from whisprbar.audio import (
 )
 from whisprbar.transcription import transcribe_audio, get_transcriber
 from whisprbar.transcript_store import save_transcript_record
-from whisprbar.flow import process_flow_text
+from whisprbar.flow import FlowOutput, process_flow_text
 from whisprbar.hotkeys import get_hotkey_manager
 from whisprbar.i18n import t
 from whisprbar.hotkey_actions import HOTKEY_ACTION_ORDER
@@ -203,6 +203,7 @@ TRANSCRIPTION_SEMAPHORE = threading.Semaphore(2)
 # from audio callback and transcription threads, so keep ownership explicit.
 _live_transcription_lock = threading.Lock()
 _active_live_transcription_session = None
+_UNSET_LIVE_SESSION = object()
 
 # PID file for singleton enforcement
 PID_FILE = Path.home() / ".cache" / "whisprbar" / "whisprbar.pid"
@@ -410,6 +411,7 @@ def toggle_recording() -> None:
     except Exception as exc:
         debug(f"[RECORDING] Toggle failed: {exc}")
         notify(f"{t('main.recording_error', cfg)}: {exc}")
+        _cancel_live_transcription_session()
         # Reset state so the app isn't stuck in a broken recording state
         state.recording = False
         state.transcribing = False
@@ -425,6 +427,7 @@ def start_recording_hotkey() -> None:
     except Exception as exc:
         debug(f"[RECORDING] Start hotkey failed: {exc}")
         notify(f"{t('main.recording_start_failed', cfg)}: {exc}")
+        _cancel_live_transcription_session()
         state.recording = False
         state.transcribing = False
         refresh_tray_indicator(state)
@@ -722,10 +725,10 @@ def prepare_openai_client() -> bool:
 def dispatch_transcript_text(
     text: str,
     output_seconds: float,
-    update_overlay_func=None,
-    show_indicator_func=None,
-    runtime_metadata: Optional[dict] = None,
-):
+    update_overlay_func: Optional[Callable[[str, str], None]] = None,
+    show_indicator_func: Optional[Callable[..., None]] = None,
+    runtime_metadata: Optional[dict[str, Any]] = None,
+) -> FlowOutput:
     """Process, persist, and paste a completed transcript."""
     if (
         show_indicator_func is not None
@@ -884,6 +887,7 @@ class _LiveTranscriptionFinish:
         self.session = session
         self.started_at = time.monotonic()
         self._done = threading.Event()
+        self._cancel_requested = threading.Event()
         self._text: Optional[str] = None
         self._error: Optional[BaseException] = None
 
@@ -906,26 +910,37 @@ class _LiveTranscriptionFinish:
         elapsed_ms = (time.monotonic() - self.started_at) * 1000
         if not self._done.is_set():
             debug("Live transcription finish timed out; falling back to batch ASR")
+            self.cancel()
+            self._thread.join(timeout=0.5)
             return None, elapsed_ms
         if self._error is not None:
             debug(f"Live transcription session failed: {self._error}; falling back to batch ASR")
+            self.cancel()
             return None, elapsed_ms
         return self._text, elapsed_ms
 
     def cancel(self) -> None:
-        if self._done.is_set():
+        if self._cancel_requested.is_set():
             return
+        self._cancel_requested.set()
         with contextlib.suppress(Exception):
             self.session.cancel()
 
 
-def _start_live_transcription_finish() -> Optional[_LiveTranscriptionFinish]:
-    """Claim and finish the active live ASR session in parallel with local processing."""
+def _claim_live_transcription_session():
+    """Detach the current live ASR session from the global recording slot."""
     global _active_live_transcription_session
 
     with _live_transcription_lock:
         live_session = _active_live_transcription_session
         _active_live_transcription_session = None
+
+    return live_session
+
+
+def _start_live_transcription_finish(session=_UNSET_LIVE_SESSION) -> Optional[_LiveTranscriptionFinish]:
+    """Start finishing a claimed live ASR session in parallel with local processing."""
+    live_session = _claim_live_transcription_session() if session is _UNSET_LIVE_SESSION else session
 
     if live_session is None:
         return None
@@ -949,46 +964,37 @@ def _transcribe_processed_audio(
 ) -> tuple[Optional[str], float]:
     """Run transcription directly and return result text plus elapsed milliseconds."""
     started_at = live_finish.started_at if live_finish is not None else time.monotonic()
-    global _active_live_transcription_session
 
     if live_finish is not None:
         text, elapsed_ms = live_finish.result()
         if text:
             return text, elapsed_ms
         debug("Live transcription session returned no text; falling back to batch ASR")
-    else:
-        with _live_transcription_lock:
-            live_session = _active_live_transcription_session
-            _active_live_transcription_session = None
-
-        if live_session is not None:
-            try:
-                text = live_session.finish()
-                elapsed_ms = (time.monotonic() - started_at) * 1000
-                if text:
-                    return text, elapsed_ms
-                debug("Live transcription session returned no text; falling back to batch ASR")
-            except Exception as exc:
-                debug(f"Live transcription session failed: {exc}; falling back to batch ASR")
 
     text = transcribe_audio(processed, language)
     elapsed_ms = (time.monotonic() - started_at) * 1000
     return text, elapsed_ms
 
 
+def _cancel_live_session(session) -> None:
+    """Cancel a claimed live ASR session."""
+    if session is not None:
+        with contextlib.suppress(Exception):
+            session.cancel()
+
+
 def _cancel_live_finish(live_finish: Optional[_LiveTranscriptionFinish]) -> None:
-    """Cancel a claimed live finish or the currently active live session."""
+    """Cancel a claimed live finish."""
     if live_finish is not None:
         try:
             live_finish.cancel()
         except Exception as exc:
             debug(f"Live transcription cancel failed: {exc}")
-    else:
-        _cancel_live_transcription_session()
 
 
 def on_recording_stop() -> None:
     """Handler called when recording stops."""
+    claimed_live_session = _claim_live_transcription_session()
     state.recording = False
     state.transcribing = True
     refresh_tray_indicator(state)
@@ -1008,7 +1014,7 @@ def on_recording_stop() -> None:
 
     if audio_data is None:
         debug("No audio data available")
-        _cancel_live_transcription_session()
+        _cancel_live_session(claimed_live_session)
         from whisprbar.ui.recording_indicator import hide_recording_indicator
         hide_recording_indicator()
         state.transcribing = False
@@ -1022,7 +1028,7 @@ def on_recording_stop() -> None:
         # Acquire semaphore to limit concurrent transcriptions
         if not TRANSCRIPTION_SEMAPHORE.acquire(blocking=False):
             debug("Transcription queue full, dropping request (max 2 concurrent)")
-            _cancel_live_transcription_session()
+            _cancel_live_session(claimed_live_session)
             notify(t("main.transcription_busy", cfg))
             state.transcribing = False
             refresh_tray_indicator(state)
@@ -1040,7 +1046,7 @@ def on_recording_stop() -> None:
 
             input_seconds = audio_data.size / SAMPLE_RATE if audio_data.size else 0.0
             audio_process_started_at = time.monotonic()
-            live_finish = _start_live_transcription_finish()
+            live_finish = _start_live_transcription_finish(claimed_live_session)
             live_session_active = live_finish is not None
 
             # Apply noise reduction only for longer recordings where it helps.

--- a/whisprbar/main.py
+++ b/whisprbar/main.py
@@ -199,6 +199,11 @@ _shutdown_event = threading.Event()
 # Limit to 2 concurrent transcriptions to prevent memory/CPU overload
 TRANSCRIPTION_SEMAPHORE = threading.Semaphore(2)
 
+# Active live transcription session for streaming-capable backends. Accessed
+# from audio callback and transcription threads, so keep ownership explicit.
+_live_transcription_lock = threading.Lock()
+_active_live_transcription_session = None
+
 # PID file for singleton enforcement
 PID_FILE = Path.home() / ".cache" / "whisprbar" / "whisprbar.pid"
 
@@ -719,6 +724,7 @@ def dispatch_transcript_text(
     output_seconds: float,
     update_overlay_func=None,
     show_indicator_func=None,
+    runtime_metadata: Optional[dict] = None,
 ):
     """Process, persist, and paste a completed transcript."""
     if (
@@ -729,7 +735,9 @@ def dispatch_transcript_text(
         from whisprbar.ui.recording_indicator import PHASE_REWRITING
         show_indicator_func(PHASE_REWRITING, cfg)
 
+    flow_started_at = time.monotonic()
     flow_output = process_flow_text(text, cfg.get("language", "de"), cfg)
+    flow_ms = (time.monotonic() - flow_started_at) * 1000
     final_text = flow_output.final_text
     state.last_transcript = final_text
 
@@ -740,18 +748,14 @@ def dispatch_transcript_text(
     history_metadata = dict(flow_output.metadata)
     history_metadata.setdefault("raw_text", flow_output.raw_text)
     history_metadata.setdefault("final_text", flow_output.final_text)
-    write_history(final_text, output_seconds, word_count, metadata=history_metadata)
-    save_transcript_record(
-        final_text,
-        output_seconds,
-        word_count,
-        metadata=history_metadata,
-        config=cfg,
-    )
+    history_metadata.setdefault("flow_ms", round(flow_ms, 1))
+    if runtime_metadata:
+        history_metadata.update(runtime_metadata)
 
     word_label_key = "main.word" if word_count == 1 else "main.words"
     words_per_second = round(word_count / output_seconds, 1) if output_seconds > 0 else 0.0
     speed_label = t("main.words_per_second", cfg)
+    paste_started_at = time.monotonic()
     word_info = f"({word_count} {t(word_label_key, cfg)} · {words_per_second:.1f} {speed_label})"
 
     if cfg.get("auto_paste_enabled"):
@@ -777,6 +781,16 @@ def dispatch_transcript_text(
             from whisprbar.ui.recording_indicator import PHASE_COMPLETE
             show_indicator_func(PHASE_COMPLETE, cfg, info=word_info)
 
+    history_metadata.setdefault("paste_ms", round((time.monotonic() - paste_started_at) * 1000, 1))
+    write_history(final_text, output_seconds, word_count, metadata=history_metadata)
+    save_transcript_record(
+        final_text,
+        output_seconds,
+        word_count,
+        metadata=history_metadata,
+        config=cfg,
+    )
+
     return flow_output
 
 
@@ -795,9 +809,103 @@ def on_recording_start() -> None:
     play_audio_feedback("start")
 
 
+def _start_live_transcription_session() -> None:
+    """Start a live ASR session for streaming-capable backends."""
+    global _active_live_transcription_session
+
+    try:
+        transcriber = get_transcriber()
+        start_streaming = getattr(transcriber, "start_streaming", None)
+        if not callable(start_streaming):
+            return
+        session = start_streaming(cfg.get("language", "de"))
+    except Exception as exc:
+        debug(f"Live transcription startup failed: {exc}")
+        return
+
+    if session is None:
+        return
+
+    old_session = None
+    with _live_transcription_lock:
+        old_session = _active_live_transcription_session
+        _active_live_transcription_session = session
+
+    if old_session is not None and old_session is not session:
+        with contextlib.suppress(Exception):
+            old_session.cancel()
+
+    debug("Live transcription session started")
+
+
+def _push_live_audio_chunk(audio_chunk) -> None:
+    """Forward a captured audio chunk to the active live ASR session."""
+    with _live_transcription_lock:
+        session = _active_live_transcription_session
+
+    if session is None:
+        return
+
+    try:
+        import numpy as np
+
+        audio = np.asarray(audio_chunk, dtype=np.float32).reshape(-1).copy()
+        if audio.size == 0:
+            return
+        session.push_audio(audio)
+    except Exception as exc:
+        debug(f"Live transcription chunk push failed: {exc}; falling back to batch ASR")
+        _cancel_live_transcription_session()
+
+
+def _cancel_live_transcription_session() -> None:
+    """Cancel and clear any active live ASR session."""
+    global _active_live_transcription_session
+
+    with _live_transcription_lock:
+        session = _active_live_transcription_session
+        _active_live_transcription_session = None
+
+    if session is not None:
+        with contextlib.suppress(Exception):
+            session.cancel()
+
+
+def _has_active_live_transcription_session() -> bool:
+    """Return whether a live ASR session is waiting to be finished."""
+    with _live_transcription_lock:
+        return _active_live_transcription_session is not None
+
+
+def _elapsed_ms(start, end) -> Optional[float]:
+    """Return rounded milliseconds between two monotonic timestamps."""
+    if start is None or end is None:
+        return None
+    try:
+        return round((float(end) - float(start)) * 1000, 1)
+    except (TypeError, ValueError):
+        return None
+
+
 def _transcribe_processed_audio(processed, language: str) -> tuple[Optional[str], float]:
     """Run transcription directly and return result text plus elapsed milliseconds."""
     started_at = time.monotonic()
+    global _active_live_transcription_session
+
+    with _live_transcription_lock:
+        live_session = _active_live_transcription_session
+        _active_live_transcription_session = None
+
+    if live_session is not None:
+        try:
+            text = live_session.finish()
+            elapsed_ms = (time.monotonic() - started_at) * 1000
+            if text:
+                return text, elapsed_ms
+            debug("Live transcription session returned no text; falling back to batch ASR")
+        except Exception as exc:
+            debug(f"Live transcription session failed: {exc}; falling back to batch ASR")
+
     text = transcribe_audio(processed, language)
     elapsed_ms = (time.monotonic() - started_at) * 1000
     return text, elapsed_ms
@@ -824,6 +932,7 @@ def on_recording_stop() -> None:
 
     if audio_data is None:
         debug("No audio data available")
+        _cancel_live_transcription_session()
         from whisprbar.ui.recording_indicator import hide_recording_indicator
         hide_recording_indicator()
         state.transcribing = False
@@ -836,6 +945,7 @@ def on_recording_stop() -> None:
         # Acquire semaphore to limit concurrent transcriptions
         if not TRANSCRIPTION_SEMAPHORE.acquire(blocking=False):
             debug("Transcription queue full, dropping request (max 2 concurrent)")
+            _cancel_live_transcription_session()
             notify(t("main.transcription_busy", cfg))
             state.transcribing = False
             refresh_tray_indicator(state)
@@ -844,15 +954,6 @@ def on_recording_stop() -> None:
             return
 
         try:
-            # Mild priority reduction to keep UI responsive, but not so aggressive
-            # that transcription (an interactive action) becomes slow.
-            try:
-                import os
-                os.nice(3)
-                debug("Transcription thread running with nice priority +3")
-            except (OSError, AttributeError) as exc:
-                debug(f"Could not set nice priority: {exc}")
-
             # Import here to avoid circular dependencies
             from whisprbar.ui import show_live_overlay, update_live_overlay, hide_live_overlay
             from whisprbar.audio import apply_vad, apply_noise_reduction, SAMPLE_RATE
@@ -861,17 +962,29 @@ def on_recording_stop() -> None:
             show_live_overlay(cfg, t("main.processing_audio", cfg))
 
             input_seconds = audio_data.size / SAMPLE_RATE if audio_data.size else 0.0
+            audio_process_started_at = time.monotonic()
+            live_session_active = _has_active_live_transcription_session()
 
             # Apply noise reduction only for longer recordings where it helps.
             # noisereduce uses FFT (O(n log n)) and takes 1-10 s on long audio.
             # For short recordings (< 8 s) the benefit is negligible; skip it
             # to cut perceived latency dramatically.
             NR_MIN_SECONDS = 8.0
-            if cfg.get("noise_reduction_enabled") and input_seconds >= NR_MIN_SECONDS:
+            if (
+                cfg.get("noise_reduction_enabled")
+                and input_seconds >= NR_MIN_SECONDS
+                and not live_session_active
+            ):
                 debug(f"Applying noise reduction ({input_seconds:.1f}s recording)")
                 audio_nr = apply_noise_reduction(audio_data)
             else:
-                if cfg.get("noise_reduction_enabled") and input_seconds < NR_MIN_SECONDS:
+                if (
+                    cfg.get("noise_reduction_enabled")
+                    and input_seconds >= NR_MIN_SECONDS
+                    and live_session_active
+                ):
+                    debug("Skipping noise reduction because live ASR already has raw audio")
+                elif cfg.get("noise_reduction_enabled") and input_seconds < NR_MIN_SECONDS:
                     debug(f"Skipping noise reduction for short recording ({input_seconds:.1f}s < {NR_MIN_SECONDS}s)")
                 audio_nr = audio_data
 
@@ -879,6 +992,7 @@ def on_recording_stop() -> None:
             processed = apply_vad(audio_nr)
 
             output_seconds = processed.size / SAMPLE_RATE if processed.size else 0.0
+            audio_process_ms = (time.monotonic() - audio_process_started_at) * 1000
             debug(f"Audio: {input_seconds:.2f}s → {output_seconds:.2f}s after VAD")
 
             # Minimum audio length check (prevent hallucinations on very short/empty audio)
@@ -895,6 +1009,7 @@ def on_recording_stop() -> None:
                     debug(f"Audio too short after VAD ({output_seconds:.2f}s < {MIN_AUDIO_SECONDS}s)")
                     notify(t("main.too_short", cfg))
                     show_recording_indicator(PHASE_ERROR, cfg, info=t("indicator.too_short", cfg))
+                _cancel_live_transcription_session()
                 state.transcribing = False
                 refresh_tray_indicator(state)
                 hide_live_overlay()
@@ -912,6 +1027,7 @@ def on_recording_stop() -> None:
                 notify(t("main.only_noise", cfg))
                 from whisprbar.ui.recording_indicator import show_recording_indicator, PHASE_ERROR
                 show_recording_indicator(PHASE_ERROR, cfg, info=t("indicator.only_noise", cfg))
+                _cancel_live_transcription_session()
                 state.transcribing = False
                 refresh_tray_indicator(state)
                 hide_live_overlay()
@@ -930,6 +1046,26 @@ def on_recording_stop() -> None:
             debug(f"transcribe_audio() returned in {_transcribe_ms:.0f}ms (text={'yes' if text else 'None'})")
 
             if text:
+                runtime_metadata = {
+                    "backend": cfg.get("transcription_backend", "?"),
+                    "input_seconds": round(input_seconds, 3),
+                    "output_seconds": round(output_seconds, 3),
+                    "audio_process_ms": round(audio_process_ms, 1),
+                    "transcribe_ms": round(_transcribe_ms, 1),
+                }
+                recording_to_first_audio_ms = _elapsed_ms(
+                    recording_state.get("started_at_monotonic"),
+                    recording_state.get("first_audio_at_monotonic"),
+                )
+                if recording_to_first_audio_ms is not None:
+                    runtime_metadata["recording_to_first_audio_ms"] = recording_to_first_audio_ms
+                stop_to_asr_done_ms = _elapsed_ms(
+                    recording_state.get("stopped_at_monotonic"),
+                    time.monotonic(),
+                )
+                if stop_to_asr_done_ms is not None:
+                    runtime_metadata["stop_to_asr_done_ms"] = stop_to_asr_done_ms
+
                 debug(f"Transcription: {text}")
                 from whisprbar.ui.recording_indicator import show_recording_indicator
                 flow_output = dispatch_transcript_text(
@@ -937,6 +1073,7 @@ def on_recording_stop() -> None:
                     output_seconds,
                     update_overlay_func=update_live_overlay,
                     show_indicator_func=show_recording_indicator,
+                    runtime_metadata=runtime_metadata,
                 )
                 debug(f"Final transcript: {flow_output.final_text}")
 
@@ -1218,7 +1355,13 @@ def main() -> None:
         # Set up recording callbacks (including audio level for indicator)
         from whisprbar.audio import set_recording_callbacks
         from whisprbar.ui.recording_indicator import update_audio_level
-        set_recording_callbacks(on_recording_start, on_recording_stop, on_audio_level=update_audio_level)
+        set_recording_callbacks(
+            on_recording_start,
+            on_recording_stop,
+            on_audio_level=update_audio_level,
+            on_audio_chunk=_push_live_audio_chunk,
+            on_before_start=_start_live_transcription_session,
+        )
 
         # Install signal handlers
         install_signal_handlers()

--- a/whisprbar/main.py
+++ b/whisprbar/main.py
@@ -877,6 +877,61 @@ def _has_active_live_transcription_session() -> bool:
         return _active_live_transcription_session is not None
 
 
+class _LiveTranscriptionFinish:
+    """Finish a live ASR session while local audio processing continues."""
+
+    def __init__(self, session):
+        self.session = session
+        self.started_at = time.monotonic()
+        self._done = threading.Event()
+        self._text: Optional[str] = None
+        self._error: Optional[BaseException] = None
+
+        def live_finish_thread():
+            self._run()
+
+        self._thread = threading.Thread(target=live_finish_thread, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        try:
+            self._text = self.session.finish()
+        except BaseException as exc:
+            self._error = exc
+        finally:
+            self._done.set()
+
+    def result(self, timeout: float = 15.0) -> tuple[Optional[str], float]:
+        self._done.wait(timeout)
+        elapsed_ms = (time.monotonic() - self.started_at) * 1000
+        if not self._done.is_set():
+            debug("Live transcription finish timed out; falling back to batch ASR")
+            return None, elapsed_ms
+        if self._error is not None:
+            debug(f"Live transcription session failed: {self._error}; falling back to batch ASR")
+            return None, elapsed_ms
+        return self._text, elapsed_ms
+
+    def cancel(self) -> None:
+        if self._done.is_set():
+            return
+        with contextlib.suppress(Exception):
+            self.session.cancel()
+
+
+def _start_live_transcription_finish() -> Optional[_LiveTranscriptionFinish]:
+    """Claim and finish the active live ASR session in parallel with local processing."""
+    global _active_live_transcription_session
+
+    with _live_transcription_lock:
+        live_session = _active_live_transcription_session
+        _active_live_transcription_session = None
+
+    if live_session is None:
+        return None
+    return _LiveTranscriptionFinish(live_session)
+
+
 def _elapsed_ms(start, end) -> Optional[float]:
     """Return rounded milliseconds between two monotonic timestamps."""
     if start is None or end is None:
@@ -887,28 +942,49 @@ def _elapsed_ms(start, end) -> Optional[float]:
         return None
 
 
-def _transcribe_processed_audio(processed, language: str) -> tuple[Optional[str], float]:
+def _transcribe_processed_audio(
+    processed,
+    language: str,
+    live_finish: Optional[_LiveTranscriptionFinish] = None,
+) -> tuple[Optional[str], float]:
     """Run transcription directly and return result text plus elapsed milliseconds."""
-    started_at = time.monotonic()
+    started_at = live_finish.started_at if live_finish is not None else time.monotonic()
     global _active_live_transcription_session
 
-    with _live_transcription_lock:
-        live_session = _active_live_transcription_session
-        _active_live_transcription_session = None
+    if live_finish is not None:
+        text, elapsed_ms = live_finish.result()
+        if text:
+            return text, elapsed_ms
+        debug("Live transcription session returned no text; falling back to batch ASR")
+    else:
+        with _live_transcription_lock:
+            live_session = _active_live_transcription_session
+            _active_live_transcription_session = None
 
-    if live_session is not None:
-        try:
-            text = live_session.finish()
-            elapsed_ms = (time.monotonic() - started_at) * 1000
-            if text:
-                return text, elapsed_ms
-            debug("Live transcription session returned no text; falling back to batch ASR")
-        except Exception as exc:
-            debug(f"Live transcription session failed: {exc}; falling back to batch ASR")
+        if live_session is not None:
+            try:
+                text = live_session.finish()
+                elapsed_ms = (time.monotonic() - started_at) * 1000
+                if text:
+                    return text, elapsed_ms
+                debug("Live transcription session returned no text; falling back to batch ASR")
+            except Exception as exc:
+                debug(f"Live transcription session failed: {exc}; falling back to batch ASR")
 
     text = transcribe_audio(processed, language)
     elapsed_ms = (time.monotonic() - started_at) * 1000
     return text, elapsed_ms
+
+
+def _cancel_live_finish(live_finish: Optional[_LiveTranscriptionFinish]) -> None:
+    """Cancel a claimed live finish or the currently active live session."""
+    if live_finish is not None:
+        try:
+            live_finish.cancel()
+        except Exception as exc:
+            debug(f"Live transcription cancel failed: {exc}")
+    else:
+        _cancel_live_transcription_session()
 
 
 def on_recording_stop() -> None:
@@ -942,6 +1018,7 @@ def on_recording_stop() -> None:
     # Transcribe in background thread
     def transcribe_thread():
         success_overlay_hide_scheduled = False
+        live_finish = None
         # Acquire semaphore to limit concurrent transcriptions
         if not TRANSCRIPTION_SEMAPHORE.acquire(blocking=False):
             debug("Transcription queue full, dropping request (max 2 concurrent)")
@@ -963,7 +1040,8 @@ def on_recording_stop() -> None:
 
             input_seconds = audio_data.size / SAMPLE_RATE if audio_data.size else 0.0
             audio_process_started_at = time.monotonic()
-            live_session_active = _has_active_live_transcription_session()
+            live_finish = _start_live_transcription_finish()
+            live_session_active = live_finish is not None
 
             # Apply noise reduction only for longer recordings where it helps.
             # noisereduce uses FFT (O(n log n)) and takes 1-10 s on long audio.
@@ -1009,7 +1087,7 @@ def on_recording_stop() -> None:
                     debug(f"Audio too short after VAD ({output_seconds:.2f}s < {MIN_AUDIO_SECONDS}s)")
                     notify(t("main.too_short", cfg))
                     show_recording_indicator(PHASE_ERROR, cfg, info=t("indicator.too_short", cfg))
-                _cancel_live_transcription_session()
+                _cancel_live_finish(live_finish)
                 state.transcribing = False
                 refresh_tray_indicator(state)
                 hide_live_overlay()
@@ -1027,7 +1105,7 @@ def on_recording_stop() -> None:
                 notify(t("main.only_noise", cfg))
                 from whisprbar.ui.recording_indicator import show_recording_indicator, PHASE_ERROR
                 show_recording_indicator(PHASE_ERROR, cfg, info=t("indicator.only_noise", cfg))
-                _cancel_live_transcription_session()
+                _cancel_live_finish(live_finish)
                 state.transcribing = False
                 refresh_tray_indicator(state)
                 hide_live_overlay()
@@ -1041,6 +1119,7 @@ def on_recording_stop() -> None:
             text, _transcribe_ms = _transcribe_processed_audio(
                 processed,
                 cfg.get("language", "de"),
+                live_finish=live_finish,
             )
 
             debug(f"transcribe_audio() returned in {_transcribe_ms:.0f}ms (text={'yes' if text else 'None'})")
@@ -1102,6 +1181,7 @@ def on_recording_stop() -> None:
                 hide_live_overlay()
 
         except Exception as exc:
+            _cancel_live_finish(live_finish)
             from whisprbar.utils import error as log_error
             log_error(f"Transcription thread exception: {type(exc).__name__}: {exc}")
             from whisprbar.ui.recording_indicator import show_recording_indicator, PHASE_ERROR

--- a/whisprbar/transcription/__init__.py
+++ b/whisprbar/transcription/__init__.py
@@ -9,7 +9,7 @@ All public names are re-exported here for backwards compatibility.
 """
 
 # Base class and constants
-from .base import Transcriber, OPENAI_MODEL
+from .base import StreamingTranscriptionSession, Transcriber, OPENAI_MODEL
 
 # Backend implementations
 from .openai import OpenAITranscriber
@@ -43,6 +43,7 @@ from whisprbar.audio import split_audio_into_chunks
 __all__ = [
     # Base
     "Transcriber",
+    "StreamingTranscriptionSession",
     "OPENAI_MODEL",
     # Backends
     "OpenAITranscriber",

--- a/whisprbar/transcription/base.py
+++ b/whisprbar/transcription/base.py
@@ -13,6 +13,22 @@ import numpy as np
 OPENAI_MODEL = os.getenv("OPENAI_STT_MODEL", "gpt-4o-transcribe")
 
 
+class StreamingTranscriptionSession:
+    """Live transcription session fed from the recording callback."""
+
+    def push_audio(self, audio: np.ndarray) -> None:
+        """Send one audio chunk to the live transcription backend."""
+        raise NotImplementedError("Subclasses must implement push_audio()")
+
+    def finish(self) -> Optional[str]:
+        """Commit the stream and return the final transcript, if available."""
+        raise NotImplementedError("Subclasses must implement finish()")
+
+    def cancel(self) -> None:
+        """Cancel the stream and release backend resources."""
+        pass
+
+
 class Transcriber:
     """Abstract base class for transcription backends."""
 
@@ -47,6 +63,17 @@ class Transcriber:
             True if streaming is supported
         """
         return False
+
+    def start_streaming(
+        self,
+        language: str = "de",
+    ) -> Optional[StreamingTranscriptionSession]:
+        """Start a live transcription session if the backend supports it.
+
+        Batch-only backends return None so callers can safely fall back to
+        transcribe().
+        """
+        return None
 
     def get_name(self) -> str:
         """Get backend name for display.

--- a/whisprbar/transcription/deepgram.py
+++ b/whisprbar/transcription/deepgram.py
@@ -42,13 +42,14 @@ class DeepgramRealtimeSession(StreamingTranscriptionSession):
         self._audio_queue: queue.Queue = queue.Queue(maxsize=512)
         self._closed = threading.Event()
         self._cancelled = threading.Event()
+        self._overflowed = threading.Event()
         self._result_parts: List[str] = []
         self._error: Optional[BaseException] = None
         self._thread = threading.Thread(target=self._run_thread, daemon=True)
         self._thread.start()
 
     def push_audio(self, audio: np.ndarray) -> None:
-        if self._closed.is_set():
+        if self._closed.is_set() or self._overflowed.is_set():
             return
 
         chunk = np.asarray(audio, dtype=np.float32).reshape(-1).copy()
@@ -58,6 +59,7 @@ class DeepgramRealtimeSession(StreamingTranscriptionSession):
         try:
             self._audio_queue.put_nowait(chunk)
         except queue.Full:
+            self._overflowed.set()
             debug("Deepgram realtime queue full; dropping live chunk and relying on batch fallback")
 
     def finish(self) -> Optional[str]:
@@ -68,6 +70,9 @@ class DeepgramRealtimeSession(StreamingTranscriptionSession):
             return None
         if self._error is not None:
             debug(f"Deepgram realtime session failed: {self._error}")
+            return None
+        if self._overflowed.is_set():
+            debug("Deepgram realtime session dropped audio; falling back to batch ASR")
             return None
         transcript = " ".join(self._result_parts).strip()
         return transcript or None

--- a/whisprbar/transcription/deepgram.py
+++ b/whisprbar/transcription/deepgram.py
@@ -1,16 +1,18 @@
 """Deepgram Nova-3 transcription backend for WhisprBar."""
 
+import asyncio
 import contextlib
 import json
 import os
+import queue
 import threading
 import weakref
 import wave
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
-from .base import Transcriber
+from .base import StreamingTranscriptionSession, Transcriber
 from whisprbar.config import load_env_file_values
 from whisprbar.utils import debug, error
 from whisprbar.audio import SAMPLE_RATE, CHANNELS
@@ -18,6 +20,176 @@ from whisprbar.audio import SAMPLE_RATE, CHANNELS
 
 class DeepgramHTTPError(RuntimeError):
     """Non-retryable HTTP response from Deepgram."""
+
+
+_QUEUE_SENTINEL = object()
+
+
+def _audio_chunk_to_pcm16_bytes(audio: np.ndarray) -> bytes:
+    pcm = np.asarray(audio, dtype=np.float32).reshape(-1)
+    if pcm.size == 0:
+        return b""
+    pcm16 = (np.clip(pcm, -1.0, 1.0) * 32767).astype(np.int16)
+    return pcm16.tobytes()
+
+
+class DeepgramRealtimeSession(StreamingTranscriptionSession):
+    """Deepgram live WebSocket session fed from the audio callback."""
+
+    def __init__(self, api_key: str, url: str):
+        self.api_key = api_key
+        self.url = url
+        self._audio_queue: queue.Queue = queue.Queue(maxsize=512)
+        self._closed = threading.Event()
+        self._cancelled = threading.Event()
+        self._result_parts: List[str] = []
+        self._error: Optional[BaseException] = None
+        self._thread = threading.Thread(target=self._run_thread, daemon=True)
+        self._thread.start()
+
+    def push_audio(self, audio: np.ndarray) -> None:
+        if self._closed.is_set():
+            return
+
+        chunk = np.asarray(audio, dtype=np.float32).reshape(-1).copy()
+        if chunk.size == 0:
+            return
+
+        try:
+            self._audio_queue.put_nowait(chunk)
+        except queue.Full:
+            debug("Deepgram realtime queue full; dropping live chunk and relying on batch fallback")
+
+    def finish(self) -> Optional[str]:
+        self._close_queue()
+        self._thread.join(timeout=15.0)
+        if self._thread.is_alive():
+            debug("Deepgram realtime finish timed out")
+            return None
+        if self._error is not None:
+            debug(f"Deepgram realtime session failed: {self._error}")
+            return None
+        transcript = " ".join(self._result_parts).strip()
+        return transcript or None
+
+    def cancel(self) -> None:
+        self._cancelled.set()
+        self._close_queue()
+        self._thread.join(timeout=2.0)
+
+    def _close_queue(self) -> None:
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        try:
+            self._audio_queue.put(_QUEUE_SENTINEL, timeout=1.0)
+        except queue.Full:
+            with contextlib.suppress(queue.Empty):
+                self._audio_queue.get_nowait()
+            with contextlib.suppress(queue.Full):
+                self._audio_queue.put_nowait(_QUEUE_SENTINEL)
+
+    def _run_thread(self) -> None:
+        try:
+            asyncio.run(self._run_async())
+        except BaseException as exc:
+            self._error = exc
+
+    async def _run_async(self) -> None:
+        try:
+            import websockets
+        except Exception as exc:
+            self._error = exc
+            return
+
+        headers = {"Authorization": f"Token {self.api_key}"}
+        connect_kwargs = {
+            "additional_headers": headers,
+            "open_timeout": 10,
+            "ping_interval": 20,
+        }
+
+        try:
+            connection_cm = websockets.connect(self.url, **connect_kwargs)
+        except TypeError:
+            connect_kwargs.pop("additional_headers")
+            connect_kwargs["extra_headers"] = headers
+            connection_cm = websockets.connect(self.url, **connect_kwargs)
+
+        async with connection_cm as websocket:
+            finalize_received = asyncio.Event()
+            receiver_task = asyncio.create_task(
+                self._receive_results(websocket, finalize_received)
+            )
+            keepalive_task = asyncio.create_task(self._send_keepalives(websocket))
+
+            try:
+                while True:
+                    item = await asyncio.to_thread(self._audio_queue.get)
+                    if item is _QUEUE_SENTINEL:
+                        break
+                    if self._cancelled.is_set():
+                        return
+                    payload = _audio_chunk_to_pcm16_bytes(item)
+                    if payload:
+                        await websocket.send(payload)
+
+                if self._cancelled.is_set():
+                    return
+
+                await websocket.send(json.dumps({"type": "Finalize"}))
+                try:
+                    await asyncio.wait_for(finalize_received.wait(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    debug("Deepgram realtime finalize wait timed out")
+                await websocket.send(json.dumps({"type": "CloseStream"}))
+            finally:
+                keepalive_task.cancel()
+                receiver_task.cancel()
+                await asyncio.gather(
+                    keepalive_task,
+                    receiver_task,
+                    return_exceptions=True,
+                )
+
+    async def _send_keepalives(self, websocket) -> None:
+        while not self._closed.is_set() and not self._cancelled.is_set():
+            await asyncio.sleep(3.0)
+            if self._closed.is_set() or self._cancelled.is_set():
+                return
+            await websocket.send(json.dumps({"type": "KeepAlive"}))
+
+    async def _receive_results(self, websocket, finalize_received: asyncio.Event) -> None:
+        try:
+            async for message in websocket:
+                self._handle_message(message, finalize_received)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if not self._cancelled.is_set():
+                self._error = exc
+
+    def _handle_message(self, message, finalize_received: asyncio.Event) -> None:
+        if not isinstance(message, str):
+            return
+        try:
+            data = json.loads(message)
+        except json.JSONDecodeError:
+            return
+
+        if data.get("from_finalize") or data.get("type") == "Metadata":
+            finalize_received.set()
+
+        if data.get("type") != "Results":
+            return
+
+        try:
+            transcript = data["channel"]["alternatives"][0].get("transcript", "")
+        except (KeyError, IndexError, AttributeError):
+            return
+
+        if transcript and data.get("is_final", False):
+            self._result_parts.append(transcript.strip())
 
 
 class DeepgramTranscriber(Transcriber):
@@ -224,6 +396,16 @@ class DeepgramTranscriber(Transcriber):
             "&punctuate=true"
         )
 
+    def _build_streaming_url(self, language: str) -> str:
+        path = self._build_request_path(language)
+        return (
+            f"wss://api.deepgram.com{path}"
+            f"&encoding=linear16"
+            f"&sample_rate={SAMPLE_RATE}"
+            f"&channels={CHANNELS}"
+            "&interim_results=true"
+        )
+
     def transcribe(self, audio: np.ndarray, language: str = "de") -> Optional[str]:
         """Transcribe audio using Deepgram Nova-3 REST API.
 
@@ -304,6 +486,33 @@ class DeepgramTranscriber(Transcriber):
             "Deepgram Nova-3"
         """
         return "Deepgram Nova-3 (multilingual)"
+
+    def supports_streaming(self) -> bool:
+        """Deepgram supports live WebSocket streaming when websockets is installed."""
+        return True
+
+    def start_streaming(
+        self,
+        language: str = "de",
+    ) -> Optional[StreamingTranscriptionSession]:
+        """Start a live Deepgram WebSocket session."""
+        if not self.ensure_client():
+            return None
+
+        try:
+            import websockets  # noqa: F401
+        except Exception as exc:
+            debug(f"Deepgram realtime unavailable: {exc}")
+            return None
+
+        try:
+            return DeepgramRealtimeSession(
+                self.api_key,
+                self._build_streaming_url(language),
+            )
+        except Exception as exc:
+            debug(f"Failed to start Deepgram realtime session: {exc}")
+            return None
 
     def unload(self) -> None:
         """Unload Deepgram client and close persistent connections."""

--- a/whisprbar/transcription/deepgram.py
+++ b/whisprbar/transcription/deepgram.py
@@ -67,6 +67,7 @@ class DeepgramRealtimeSession(StreamingTranscriptionSession):
         self._thread.join(timeout=15.0)
         if self._thread.is_alive():
             debug("Deepgram realtime finish timed out")
+            self.cancel()
             return None
         if self._error is not None:
             debug(f"Deepgram realtime session failed: {self._error}")
@@ -89,6 +90,7 @@ class DeepgramRealtimeSession(StreamingTranscriptionSession):
         try:
             self._audio_queue.put(_QUEUE_SENTINEL, timeout=1.0)
         except queue.Full:
+            self._overflowed.set()
             with contextlib.suppress(queue.Empty):
                 self._audio_queue.get_nowait()
             with contextlib.suppress(queue.Full):
@@ -108,54 +110,64 @@ class DeepgramRealtimeSession(StreamingTranscriptionSession):
             return
 
         headers = {"Authorization": f"Token {self.api_key}"}
-        connect_kwargs = {
-            "additional_headers": headers,
+        base_connect_kwargs = {
             "open_timeout": 10,
             "ping_interval": 20,
         }
 
-        try:
-            connection_cm = websockets.connect(self.url, **connect_kwargs)
-        except TypeError:
-            connect_kwargs.pop("additional_headers")
-            connect_kwargs["extra_headers"] = headers
-            connection_cm = websockets.connect(self.url, **connect_kwargs)
-
-        async with connection_cm as websocket:
-            finalize_received = asyncio.Event()
-            receiver_task = asyncio.create_task(
-                self._receive_results(websocket, finalize_received)
-            )
-            keepalive_task = asyncio.create_task(self._send_keepalives(websocket))
-
+        for header_arg in ("additional_headers", "extra_headers"):
+            connect_kwargs = dict(base_connect_kwargs)
+            connect_kwargs[header_arg] = headers
             try:
-                while True:
-                    item = await asyncio.to_thread(self._audio_queue.get)
-                    if item is _QUEUE_SENTINEL:
-                        break
-                    if self._cancelled.is_set():
-                        return
-                    payload = _audio_chunk_to_pcm16_bytes(item)
-                    if payload:
-                        await websocket.send(payload)
+                async with websockets.connect(self.url, **connect_kwargs) as websocket:
+                    await self._run_websocket(websocket)
+                return
+            except TypeError as exc:
+                if header_arg == "additional_headers" and "additional_headers" in str(exc):
+                    debug("Deepgram realtime retrying websocket connect with extra_headers")
+                    continue
+                raise
 
+    async def _run_websocket(self, websocket) -> None:
+        finalize_received = asyncio.Event()
+        receiver_task = asyncio.create_task(
+            self._receive_results(websocket, finalize_received)
+        )
+        keepalive_task = asyncio.create_task(self._send_keepalives(websocket))
+
+        try:
+            while True:
+                item = await asyncio.to_thread(self._audio_queue.get)
+                if item is _QUEUE_SENTINEL:
+                    break
                 if self._cancelled.is_set():
                     return
+                payload = _audio_chunk_to_pcm16_bytes(item)
+                if payload:
+                    await websocket.send(payload)
 
-                await websocket.send(json.dumps({"type": "Finalize"}))
-                try:
-                    await asyncio.wait_for(finalize_received.wait(), timeout=5.0)
-                except asyncio.TimeoutError:
-                    debug("Deepgram realtime finalize wait timed out")
-                await websocket.send(json.dumps({"type": "CloseStream"}))
-            finally:
-                keepalive_task.cancel()
+            if self._cancelled.is_set():
+                return
+
+            await websocket.send(json.dumps({"type": "Finalize"}))
+            try:
+                await asyncio.wait_for(finalize_received.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                debug("Deepgram realtime finalize wait timed out")
+            await websocket.send(json.dumps({"type": "CloseStream"}))
+            try:
+                await asyncio.wait_for(receiver_task, timeout=2.0)
+            except asyncio.TimeoutError:
+                debug("Deepgram realtime close wait timed out")
+        finally:
+            keepalive_task.cancel()
+            if not receiver_task.done():
                 receiver_task.cancel()
-                await asyncio.gather(
-                    keepalive_task,
-                    receiver_task,
-                    return_exceptions=True,
-                )
+            await asyncio.gather(
+                keepalive_task,
+                receiver_task,
+                return_exceptions=True,
+            )
 
     async def _send_keepalives(self, websocket) -> None:
         while not self._closed.is_set() and not self._cancelled.is_set():

--- a/whisprbar/transcription/elevenlabs.py
+++ b/whisprbar/transcription/elevenlabs.py
@@ -43,6 +43,7 @@ class ElevenLabsRealtimeSession(StreamingTranscriptionSession):
         self._audio_queue: queue.Queue = queue.Queue(maxsize=512)
         self._closed = threading.Event()
         self._cancelled = threading.Event()
+        self._overflowed = threading.Event()
         self._result_parts: list[str] = []
         self._error: Optional[BaseException] = None
         self._thread = threading.Thread(target=self._run_thread, daemon=True)
@@ -50,7 +51,7 @@ class ElevenLabsRealtimeSession(StreamingTranscriptionSession):
 
     def push_audio(self, audio: np.ndarray) -> None:
         """Queue an audio chunk without blocking the sounddevice callback."""
-        if self._closed.is_set():
+        if self._closed.is_set() or self._overflowed.is_set():
             return
 
         chunk = np.asarray(audio, dtype=np.float32).reshape(-1).copy()
@@ -60,6 +61,7 @@ class ElevenLabsRealtimeSession(StreamingTranscriptionSession):
         try:
             self._audio_queue.put_nowait(chunk)
         except queue.Full:
+            self._overflowed.set()
             debug("ElevenLabs realtime queue full; dropping live chunk and relying on batch fallback")
 
     def finish(self) -> Optional[str]:
@@ -71,6 +73,9 @@ class ElevenLabsRealtimeSession(StreamingTranscriptionSession):
             return None
         if self._error is not None:
             debug(f"ElevenLabs realtime session failed: {self._error}")
+            return None
+        if self._overflowed.is_set():
+            debug("ElevenLabs realtime session dropped audio; falling back to batch ASR")
             return None
         transcript = " ".join(self._result_parts).strip()
         return transcript or None

--- a/whisprbar/transcription/elevenlabs.py
+++ b/whisprbar/transcription/elevenlabs.py
@@ -1,15 +1,165 @@
 """ElevenLabs Scribe v2 Realtime transcription backend for WhisprBar."""
 
+import asyncio
+import base64
+import contextlib
 import os
+import queue
 import threading
 from typing import Optional
 
 import numpy as np
 
-from .base import Transcriber
+from .base import StreamingTranscriptionSession, Transcriber
 from whisprbar.config import load_env_file_values
 from whisprbar.utils import debug
 from whisprbar.audio import SAMPLE_RATE
+
+
+_QUEUE_SENTINEL = object()
+
+
+def _audio_chunk_to_base64(audio: np.ndarray) -> str:
+    """Convert float32 mono audio to base64 PCM16 for ElevenLabs realtime."""
+    pcm = np.asarray(audio, dtype=np.float32).reshape(-1)
+    if pcm.size == 0:
+        return ""
+    pcm16 = (np.clip(pcm, -1.0, 1.0) * 32767).astype(np.int16)
+    return base64.b64encode(pcm16.tobytes()).decode()
+
+
+def _extract_transcript_text(data) -> str:
+    if isinstance(data, dict):
+        return str(data.get("text", "") or "")
+    return str(getattr(data, "text", "") or "")
+
+
+class ElevenLabsRealtimeSession(StreamingTranscriptionSession):
+    """Background ElevenLabs realtime session fed by the audio callback."""
+
+    def __init__(self, client, language: str):
+        self.client = client
+        self.language = language
+        self._audio_queue: queue.Queue = queue.Queue(maxsize=512)
+        self._closed = threading.Event()
+        self._cancelled = threading.Event()
+        self._result_parts: list[str] = []
+        self._error: Optional[BaseException] = None
+        self._thread = threading.Thread(target=self._run_thread, daemon=True)
+        self._thread.start()
+
+    def push_audio(self, audio: np.ndarray) -> None:
+        """Queue an audio chunk without blocking the sounddevice callback."""
+        if self._closed.is_set():
+            return
+
+        chunk = np.asarray(audio, dtype=np.float32).reshape(-1).copy()
+        if chunk.size == 0:
+            return
+
+        try:
+            self._audio_queue.put_nowait(chunk)
+        except queue.Full:
+            debug("ElevenLabs realtime queue full; dropping live chunk and relying on batch fallback")
+
+    def finish(self) -> Optional[str]:
+        """Commit the realtime stream and return the committed transcript."""
+        self._close_queue()
+        self._thread.join(timeout=15.0)
+        if self._thread.is_alive():
+            debug("ElevenLabs realtime finish timed out")
+            return None
+        if self._error is not None:
+            debug(f"ElevenLabs realtime session failed: {self._error}")
+            return None
+        transcript = " ".join(self._result_parts).strip()
+        return transcript or None
+
+    def cancel(self) -> None:
+        """Cancel the realtime stream and close resources."""
+        self._cancelled.set()
+        self._close_queue()
+        self._thread.join(timeout=2.0)
+
+    def _close_queue(self) -> None:
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        try:
+            self._audio_queue.put(_QUEUE_SENTINEL, timeout=1.0)
+        except queue.Full:
+            with contextlib.suppress(queue.Empty):
+                self._audio_queue.get_nowait()
+            with contextlib.suppress(queue.Full):
+                self._audio_queue.put_nowait(_QUEUE_SENTINEL)
+
+    def _run_thread(self) -> None:
+        try:
+            asyncio.run(self._run_async())
+        except BaseException as exc:
+            self._error = exc
+
+    async def _run_async(self) -> None:
+        from elevenlabs import (
+            AudioFormat,
+            CommitStrategy,
+            RealtimeAudioOptions,
+            RealtimeEvents,
+        )
+
+        connection = None
+        transcript_received = asyncio.Event()
+
+        try:
+            connection = await asyncio.wait_for(
+                self.client.speech_to_text.realtime.connect(
+                    RealtimeAudioOptions(
+                        model_id="scribe_v2_realtime",
+                        audio_format=AudioFormat.PCM_16000,
+                        sample_rate=SAMPLE_RATE,
+                        commit_strategy=CommitStrategy.MANUAL,
+                        language_code=self.language,
+                    )
+                ),
+                timeout=30.0,
+            )
+
+            def on_committed_transcript(data):
+                text = _extract_transcript_text(data)
+                if text:
+                    self._result_parts.append(text)
+                    debug(f"ElevenLabs realtime committed: {text}")
+                    transcript_received.set()
+
+            connection.on(RealtimeEvents.COMMITTED_TRANSCRIPT, on_committed_transcript)
+
+            while True:
+                item = await asyncio.to_thread(self._audio_queue.get)
+                if item is _QUEUE_SENTINEL:
+                    break
+                if self._cancelled.is_set():
+                    return
+                audio_base64 = _audio_chunk_to_base64(item)
+                if audio_base64:
+                    await connection.send(
+                        {"audio_base_64": audio_base64, "sample_rate": SAMPLE_RATE}
+                    )
+
+            if self._cancelled.is_set():
+                return
+
+            await connection.commit()
+
+            try:
+                await asyncio.wait_for(transcript_received.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                debug("ElevenLabs realtime transcript wait timed out")
+        finally:
+            if connection is not None:
+                try:
+                    await connection.close()
+                except Exception as close_exc:
+                    debug(f"Error closing ElevenLabs realtime connection: {close_exc}")
 
 
 class ElevenLabsTranscriber(Transcriber):
@@ -172,6 +322,23 @@ class ElevenLabsTranscriber(Transcriber):
 
         except Exception as exc:
             debug(f"ElevenLabs transcription failed: {exc}")
+            return None
+
+    def supports_streaming(self) -> bool:
+        """ElevenLabs uses a true realtime transcription session."""
+        return True
+
+    def start_streaming(
+        self,
+        language: str = "de",
+    ) -> Optional[StreamingTranscriptionSession]:
+        """Start a realtime session that receives audio during recording."""
+        if not self.ensure_client():
+            return None
+        try:
+            return ElevenLabsRealtimeSession(self.client, language)
+        except Exception as exc:
+            debug(f"Failed to start ElevenLabs realtime session: {exc}")
             return None
 
     def get_name(self) -> str:

--- a/whisprbar/transcription/elevenlabs.py
+++ b/whisprbar/transcription/elevenlabs.py
@@ -70,6 +70,7 @@ class ElevenLabsRealtimeSession(StreamingTranscriptionSession):
         self._thread.join(timeout=15.0)
         if self._thread.is_alive():
             debug("ElevenLabs realtime finish timed out")
+            self.cancel()
             return None
         if self._error is not None:
             debug(f"ElevenLabs realtime session failed: {self._error}")
@@ -93,6 +94,7 @@ class ElevenLabsRealtimeSession(StreamingTranscriptionSession):
         try:
             self._audio_queue.put(_QUEUE_SENTINEL, timeout=1.0)
         except queue.Full:
+            self._overflowed.set()
             with contextlib.suppress(queue.Empty):
                 self._audio_queue.get_nowait()
             with contextlib.suppress(queue.Full):

--- a/whisprbar/ui/settings.py
+++ b/whisprbar/ui/settings.py
@@ -482,13 +482,13 @@ def open_settings_window(cfg: dict, state: dict, on_save: Optional[Callable] = N
         paste_row = make_row("  Paste-Modus", paste_combo, tooltip="Methode für Auto-Paste")
         basis_page.pack_start(paste_row, False, False, 0)
 
-        paste_delay_adjustment = Gtk.Adjustment(value=float(cfg.get("paste_delay_ms", 250) or 0), lower=0.0, upper=2000.0, step_increment=25.0, page_increment=100.0)
+        paste_delay_adjustment = Gtk.Adjustment(value=float(cfg.get("paste_delay_ms", 0) or 0), lower=0.0, upper=2000.0, step_increment=25.0, page_increment=100.0)
         paste_delay_spin = Gtk.SpinButton()
         paste_delay_spin.set_adjustment(paste_delay_adjustment)
         paste_delay_spin.set_numeric(True)
-        paste_delay_spin.set_value(float(cfg.get("paste_delay_ms", 250) or 0))
+        paste_delay_spin.set_value(float(cfg.get("paste_delay_ms", 0) or 0))
         paste_delay_spin.set_digits(0)
-        paste_delay_row = make_row("  Paste-Verzögerung (ms)", paste_delay_spin, defaults_text="(Standard: 250)")
+        paste_delay_row = make_row("  Paste-Verzögerung (ms)", paste_delay_spin, defaults_text="(Standard: 0)")
         basis_page.pack_start(paste_delay_row, False, False, 0)
 
         def sync_paste_options(*_args) -> None:
@@ -809,7 +809,8 @@ def open_settings_window(cfg: dict, state: dict, on_save: Optional[Callable] = N
         vad_rows.append(auto_stop_duration_row)
         adv_page.pack_start(auto_stop_duration_row, False, False, 0)
 
-        stop_tail_grace = int(cfg.get("stop_tail_grace_ms", 500) or 500)
+        stop_tail_grace = cfg.get("stop_tail_grace_ms", 200)
+        stop_tail_grace = 200 if stop_tail_grace is None else int(stop_tail_grace)
         stop_tail_scale = Gtk.Scale.new_with_range(Gtk.Orientation.HORIZONTAL, 100.0, 2000.0, 100.0)
         stop_tail_scale.set_digits(0)
         stop_tail_scale.set_value(max(100, min(2000, float(stop_tail_grace))))
@@ -818,7 +819,7 @@ def open_settings_window(cfg: dict, state: dict, on_save: Optional[Callable] = N
         stop_tail_scale.set_hexpand(True)
         stop_tail_scale.clear_marks()
         stop_tail_scale.connect("format-value", lambda scale, value: f"{int(value)} ms")
-        stop_tail_row = make_row("  Aufnahme-Puffer (ms)", stop_tail_scale, expand=True, defaults_text="(Standard: 500)")
+        stop_tail_row = make_row("  Aufnahme-Puffer (ms)", stop_tail_scale, expand=True, defaults_text="(Standard: 200)")
         vad_rows.append(stop_tail_row)
         adv_page.pack_start(stop_tail_row, False, False, 0)
 

--- a/whisprbar/ui/settings_webview.py
+++ b/whisprbar/ui/settings_webview.py
@@ -182,13 +182,14 @@ def _field(
             for key, attr_value in input_attrs.items()
         )
     unit_html = f'<span class="wb-unit">{escape(unit)}</span>' if unit else ""
+    field_value = "" if value is None else str(value)
     return f"""
       <label class="wb-row"{_visible_attr(visible_when)}>
         <span class="wb-row-label">
           <b>{escape(label)}</b>
           <span>{escape(description)}</span>
         </span>
-        <span class="wb-value-control"><input type="{escape(input_type)}" name="{escape(name)}" value="{escape(str(value or ''))}"{attrs}>{unit_html}</span>
+        <span class="wb-value-control"><input type="{escape(input_type)}" name="{escape(name)}" value="{escape(field_value)}"{attrs}>{unit_html}</span>
       </label>
     """
 
@@ -582,7 +583,7 @@ def apply_settings_payload(
     config["notifications_enabled"] = _bool_value(_setting(settings, "notifications_enabled", config.get("notifications_enabled", True)))
     config["paste_sequence"] = str(_setting(settings, "paste_sequence", config.get("paste_sequence", "auto")) or "auto")
     config["paste_delay_ms"] = _clamp_int(
-        _int_value(_setting(settings, "paste_delay_ms", config.get("paste_delay_ms", 250)), 250),
+        _int_value(_setting(settings, "paste_delay_ms", config.get("paste_delay_ms", 0)), 0),
         0,
         5000,
     )
@@ -652,7 +653,7 @@ def apply_settings_payload(
         1,
     )
     config["stop_tail_grace_ms"] = _clamp_int(
-        _int_value(_setting(settings, "stop_tail_grace_ms", config.get("stop_tail_grace_ms", 500)), 500),
+        _int_value(_setting(settings, "stop_tail_grace_ms", config.get("stop_tail_grace_ms", 200)), 200),
         0,
         2000,
     )
@@ -907,7 +908,7 @@ def generate_settings_html(
             "paste_delay_ms",
             tr("setting.paste_delay"),
             tr("setting.paste_delay_desc"),
-            config.get("paste_delay_ms", 250),
+            config.get("paste_delay_ms", 0),
             minimum=0,
             maximum=5000,
             step=50,
@@ -1293,7 +1294,7 @@ def generate_settings_html(
             "stop_tail_grace_ms",
             tr("setting.recording_tail_buffer"),
             tr("setting.recording_tail_buffer_desc"),
-            config.get("stop_tail_grace_ms", 500),
+            config.get("stop_tail_grace_ms", 200),
             minimum=0,
             maximum=2000,
             step=50,


### PR DESCRIPTION
## Summary
- Add a streaming transcription session interface and wire Deepgram/ElevenLabs to receive live audio chunks while recording is still active.
- Prefer live ASR results at stop time, with batch transcription fallback if a live session fails or returns no text.
- Reduce avoidable local latency by defaulting paste delay to 0 ms, stop-tail grace to 200 ms, skipping noise reduction for active live ASR, and removing Linux process priority lowering.
- Record runtime latency metadata for audio processing, transcription, Flow, paste, and recording-to-first-audio timing.

## Verification
- `./.venv/Scripts/python.exe -m pytest tests/test_audio.py tests/test_transcription.py tests/test_paste.py tests/test_main_flow_actions.py tests/test_main_flow_integration.py tests/test_flow_context.py tests/test_flow_formatting.py tests/test_flow_rewrite.py -q` -> 101 passed, 2 skipped
- `./.venv/Scripts/python.exe -m compileall -q whisprbar tests` -> passed
- `./.venv/Scripts/python.exe -m pip check` -> No broken requirements found
- `git diff --cached --check` before commit -> passed

## Notes
- No paid/live API traffic was used for benchmarking; realtime behavior is covered with mocked session tests.
- Local full `pytest -q` on Windows was attempted during optimization and still has 12 existing Windows portability failures around POSIX file modes, `ls`, XDG path separators, and `/tmp` path assumptions. The focused performance and integration suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live streaming transcription for Deepgram and ElevenLabs to show results while recording stays active
  * Transcripts are persisted in a local SQLite database with structured metadata
  * Read-only Settings → **Analysis** tab with transcript collection counts and sources
  * Runtime latency metadata added across audio processing and transcription
* **Changed**
  * Default paste delay set to 0 ms; stop-tail grace reduced to 200 ms
  * Live transcription is preferred over batch fallback; when chunks drop under load, behavior shifts to batch to ensure stability
  * Noise reduction is skipped when live transcription is active
* **Bug Fixes**
  * Improved live session race handling and cleanup; preserves Deepgram final results received after stream close
* **Documentation/Chores**
  * Python support raised to 3.10+
<!-- end of auto-generated comment: release notes by coderabbit.ai -->